### PR TITLE
Setup autologin from a cookie for development purposes

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -3,5 +3,6 @@ export default angular.module('app', [
   'ngMessages',
   'ngMaterial',
   'ngAnimate',
+  'ngCookies',
   'md.data.table',
 ])

--- a/src/app/components/login/login.js
+++ b/src/app/components/login/login.js
@@ -12,16 +12,17 @@ app.component('login', {
     onLogin: '&',
   },
   controller: class login {
-    constructor ($scope, $rootScope, $timeout, $document, $mdDialog, $mdMedia) {
+    constructor ($scope, $rootScope, $timeout, $document, $mdDialog, $mdMedia, $cookies) {
       this.$scope = $scope
       this.$rootScope = $rootScope
       this.$timeout = $timeout
       this.$document = $document
       this.$mdDialog = $mdDialog
       this.$mdMedia = $mdMedia
+      this.$cookies = $cookies
 
       this.$scope.$watch('$ctrl.input_passphrase', this.isValid.bind(this))
-      // this.$timeout(this.devTestAccount.bind(this), 200)
+      this.$timeout(this.devTestAccount.bind(this), 200)
 
       this.$scope.$watch(() => {
         return this.$mdMedia('xs') || this.$mdMedia('sm');
@@ -178,8 +179,10 @@ app.component('login', {
     }
 
     devTestAccount () {
-      this.input_passphrase = 'stay undo beyond powder sand laptop grow gloom apology hamster primary arrive'
-      this.$timeout(this.go.bind(this), 100)
+      this.input_passphrase = this.$cookies.get('passphrase');
+      if (this.input_passphrase) {
+        this.$timeout(this.go.bind(this), 100)
+      }
     }
 
     fix (v) {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -3,6 +3,7 @@ import 'jquery'
 
 import 'angular'
 import 'angular-animate'
+import 'angular-cookies'
 import 'angular-aria'
 import 'angular-messages'
 import 'angular-material'

--- a/src/app/services/peers/peers.js
+++ b/src/app/services/peers/peers.js
@@ -5,7 +5,7 @@ import './peer'
 
 const UPDATE_INTERVAL_CHECK = 10000
 
-app.factory('$peers', ($peer, $timeout) => {
+app.factory('$peers', ($peer, $timeout, $cookies) => {
   class $peers {
     constructor () {
       this.stack = {
@@ -38,7 +38,9 @@ app.factory('$peers', ($peer, $timeout) => {
 
     setActive () {
       this.active = _.chain([])
-        .concat(this.stack.official, this.stack.public)
+        .concat($cookies.get('peerStack') == 'testnet' ?
+          this.stack.testnet : this.stack.official,
+          this.stack.public)
         .sample()
         .value()
 

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "angular": "^1.5.8",
     "angular-animate": "^1.5.8",
+    "angular-cookies": "=1.5.8",
     "angular-aria": "^1.5.8",
     "angular-material": "^1.1.1",
     "angular-material-data-table": "^0.10.9",


### PR DESCRIPTION
A way to setup the cookie is to run the following in browser console:
```
angular.element(document.body).injector().get('$cookies').put('passphrase', 'stay undo beyond powder sand laptop grow gloom apology hamster primary arrive')
```
It's done the same way in lisk-ui: https://github.com/LiskHQ/lisk-ui/commit/af3c1e0b5cbf050d79ec63c431f9fb74c841d68d