### PR TITLE
Fix floating-point arithmetic rounding error in balance #80

### DIFF
--- a/src/app/services/lsk.js
+++ b/src/app/services/lsk.js
@@ -1,8 +1,10 @@
-import numeral from 'numeral';
+import BigNumber from 'bignumber.js';
+
+BigNumber.config({ ERRORS: false });
 
 app.factory('lsk', () => ({
   normalize(value) {
-    return numeral(parseInt(value, 10) || 0).divide(Math.pow(10, 8)).format('0.0[0000000]');
+    return new BigNumber(value || 0).dividedBy(Math.pow(10, 8)).toString();
   },
   from(value) {
     return parseInt(value * Math.pow(10, 8), 10);

--- a/src/package.json
+++ b/src/package.json
@@ -20,13 +20,13 @@
     "angular-material-data-table": "=0.10.9",
     "angular-messages": "=1.5.8",
     "babel-polyfill": "=6.9.1",
+    "bignumber.js": "^4.0.0",
     "bitcore-mnemonic": "=1.1.1",
     "debug": "=2.2.0",
     "jquery": "=2.2.4",
     "lisk-js": "git://github.com/liskHQ/lisk-js.git#development",
     "lodash": "=4.16.4",
-    "moment": "=2.15.1",
-    "numeral": "=1.5.3"
+    "moment": "=2.15.1"
   },
   "devDependencies": {
     "angular-mocks": "=1.5.8",

--- a/src/package.json
+++ b/src/package.json
@@ -20,7 +20,7 @@
     "angular-material-data-table": "=0.10.9",
     "angular-messages": "=1.5.8",
     "babel-polyfill": "=6.9.1",
-    "bignumber.js": "^4.0.0",
+    "bignumber.js": "=4.0.0",
     "bitcore-mnemonic": "=1.1.1",
     "debug": "=2.2.0",
     "jquery": "=2.2.4",


### PR DESCRIPTION
The error was:
balance returned form the API is: "balance":"9999997590000000"
but the ui shows: 99999975.90000001 LSK

Fixed by switching from numeral to BigNumber.js