### PR TITLE
Fix build by not minifying - Closes #94

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -67,7 +67,6 @@
     "less": "=2.7.1",
     "less-loader": "=2.2.3",
     "mocha": "=3.2.0",
-    "ng-annotate-webpack-plugin": "=0.1.2",
     "nyc": "=10.1.2",
     "phantomjs": "=2.1.7",
     "phantomjs-prebuilt": "=2.1.14",

--- a/src/webpack.config.babel.js
+++ b/src/webpack.config.babel.js
@@ -4,7 +4,6 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const validate = require('webpack-validator');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 const nodeEnvironment = process.env.NODE_ENV;
@@ -50,17 +49,6 @@ const html = () => ({
       minify: {
         collapseWhitespace: true,
         minifyCSS: true,
-      },
-    }),
-  ],
-});
-
-const minify = () => ({
-  plugins: [
-    new ngAnnotatePlugin(), // eslint-disable-line new-cap
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false,
       },
     }),
   ],
@@ -170,7 +158,7 @@ let config;
 
 switch (process.env.npm_lifecycle_event) {
   case 'build':
-    config = merge(common, clean(path.join(PATHS.build, '*')), minify(), html(), provide(), babel(), pug(), less(), css(), json(), png(), fonts());
+    config = merge(common, clean(path.join(PATHS.build, '*')), html(), provide(), babel(), pug(), less(), css(), json(), png(), fonts());
     break;
   default:
     config = merge(common, devServer(), { devtool: 'eval-source-map' }, html(), provide(), babel(), pug(), less(), css(), json(), png(), fonts());


### PR DESCRIPTION
The error reported in Issue #94 is caused by source code being minified:
https://docs.angularjs.org/error/$injector/unpr?p0=eProvider%20%3C-%20e
I don't understand why exactly it happens. We are using
ng-annotate-webpack-plugin to handle that, but for some reason it
stopped working.

Without minification everything worked great, so I tried how big would
the electron app be without minification and it turns out that at least
the Mac version is almost the same (~40MB vs. ~41MB), so I decided to
remove minification.

It has a very pleasant side effect: build time goes from ~3 minutes
to ~11 seconds.

The app.js goes from ~2MB to ~9MB, so if we want an official web version
in the future, we have to revisit this and optimize the webpack build.
But right now it is ok for the Electron app.

Closes #94 