### PR TITLE
Update electron build dependencies - Closes #113

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-nano",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lisk Nano",
   "main": "main.js",
   "author":{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-nano",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lisk Nano",
   "homepage": "https://github.com/LiskHQ/lisk-nano",
   "bugs": "https://github.com/LiskHQ/lisk-nano/issues",
@@ -18,16 +18,15 @@
     "url": "https://github.com/LiskHQ/lisk-nano"
   },
   "devDependencies": {
-    "electron": "=1.4.4",
-    "electron-builder": "=7.14.2"
+    "electron": "=1.6.2",
+    "electron-builder": "=16.8.3"
   },
   "build": {
     "appId": "io.lisk.nano",
-    "category": "finance",
     "productName": "Lisk Nano",
     "win": {
       "target": "nsis"
     }
   },
-  "license": "MIT"
+  "license": "GPL-3.0"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-nano",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lisk Nano",
   "scripts": {
     "build": "webpack --profile --progress --display-modules --display-exclude --display-chunks --display-cached --display-cached-assets",


### PR DESCRIPTION
The versions used previously are out of date. These new versions provide better support in the event of an issue.

Also in `package.json`:

- Bumping version to `0.2.0`
- Updating license field

Closes #113