### PR TITLE
Distinguish input and output in sign/verify message - Closes #150

### DIFF
--- a/src/app/components/sign-verify/sign-message.pug
+++ b/src/app/components/sign-verify/sign-message.pug
@@ -10,7 +10,7 @@ div
       md-input-container.md-block
         label Message
         textarea(name='message', ng-model='$ctrl.message', ng-change='$ctrl.sign()', md-autofocus)
-    div
+    div(ng-show='$ctrl.result')
       md-input-container.md-block
         label Result
-        textarea(name='result', ng-model='$ctrl.result')
+        textarea(name='result', ng-model='$ctrl.result', readonly)

--- a/src/app/components/sign-verify/verify-message.pug
+++ b/src/app/components/sign-verify/verify-message.pug
@@ -17,8 +17,8 @@ div
         textarea(name='signature', ng-model='$ctrl.signature.value', ng-change='$ctrl.verify()')
         div(ng-messages='$ctrl.signature.error')
           div(ng-message='invalid') Invalid
-    div
+    div(ng-show='$ctrl.result')
       md-input-container.md-block
         label Original Message
-        textarea(name='result', ng-model='$ctrl.result')
+        textarea(name='result', ng-model='$ctrl.result', readonly)
 


### PR DESCRIPTION
By making output fields readonly and visible only when not empty.

Closes #150