### PR TITLE
Move $peers service account-related methods to Account - Closes #169

### DIFF
--- a/src/app/components/main/main.js
+++ b/src/app/components/main/main.js
@@ -31,7 +31,7 @@ app.component('main', {
 
       this.$rootScope.prelogged = true;
 
-      this.$peers.setActive();
+      this.$peers.setActive(this.account.get());
 
       this.update()
         .then(() => {
@@ -66,7 +66,7 @@ app.component('main', {
 
     update() {
       this.$rootScope.reset();
-      return this.$peers.active.getAccountPromise(this.account.get().address)
+      return this.account.getAccountPromise(this.account.get().address)
         .then((res) => {
           this.account.set({ balance: res.balance });
         })

--- a/src/app/components/main/setSecondPassDirective.js
+++ b/src/app/components/main/setSecondPassDirective.js
@@ -1,6 +1,6 @@
 import './secondPass.less';
 
-app.directive('setSecondPass', (setSecondPass, $peers, $rootScope, dialog) => {
+app.directive('setSecondPass', (setSecondPass, Account, $rootScope, dialog) => {
   /* eslint no-param-reassign: ["error", { "props": false }] */
   const SetSecondPassLink = function (scope, element, attrs) {
     element.bind('click', () => {
@@ -8,7 +8,7 @@ app.directive('setSecondPass', (setSecondPass, $peers, $rootScope, dialog) => {
     });
 
     scope.passConfirmSubmit = (secondsecret) => {
-      $peers.active.setSignature(secondsecret, attrs.publicKey, attrs.passphrase)
+      Account.setSignature(secondsecret, attrs.publicKey, attrs.passphrase)
         .then(() => {
           dialog.successAlert('Your second passphrase was successfully registered.');
         })

--- a/src/app/components/main/setSecondPassDirective.js
+++ b/src/app/components/main/setSecondPassDirective.js
@@ -8,7 +8,7 @@ app.directive('setSecondPass', (setSecondPass, Account, $rootScope, dialog) => {
     });
 
     scope.passConfirmSubmit = (secondsecret) => {
-      Account.setSignature(secondsecret, attrs.publicKey, attrs.passphrase)
+      Account.setSecondSecret(secondsecret, attrs.publicKey, attrs.passphrase)
         .then(() => {
           dialog.successAlert('Your second passphrase was successfully registered.');
         })

--- a/src/app/components/send/send.js
+++ b/src/app/components/send/send.js
@@ -79,7 +79,7 @@ app.component('send', {
 
       this.promptSecondPassphrase()
         .then((secondPassphrase) => {
-          this.$peers.active.sendLSKPromise(
+          this.account.sendLSK(
             this.recipient.value,
             this.amount.raw,
             this.account.get().passphrase,

--- a/src/app/components/transactions/transactions.js
+++ b/src/app/components/transactions/transactions.js
@@ -66,7 +66,7 @@ app.component('transactions', {
         limit = 10;
       }
 
-      return this.$peers.listTransactions(this.account.get().address, limit)
+      return this.account.listTransactions(this.account.get().address, limit)
         .then(this._processTransactionsResponse.bind(this))
         .catch(() => {
           this.transactions = [];

--- a/src/app/services/account.js
+++ b/src/app/services/account.js
@@ -48,7 +48,8 @@ app.factory('Account', function ($rootScope, $peers, $q) {
     return deferred.promise;
   };
 
-  this.sendLSK = (recipientId, amount, passphrase, secondPassphrase) => $peers.sendRequestPromise('transactions', { recipientId, amount, secret, secondSecret });
+  this.sendLSK = (recipientId, amount, secret, secondSecret) => $peers.sendRequestPromise(
+    'transactions', { recipientId, amount, secret, secondSecret });
 
   this.listTransactions = (address, limit, offset) => $peers.sendRequestPromise('transactions', {
     senderId: address,
@@ -57,7 +58,8 @@ app.factory('Account', function ($rootScope, $peers, $q) {
     offset: offset || 0,
   });
 
-  this.setSignature = (secondSecret, publicKey, secret) => $peers.sendRequestPromise('signatures', { secondSecret, publicKey, secret });
+  this.setSignature = (secondSecret, publicKey, secret) => $peers.sendRequestPromise(
+    'signatures', { secondSecret, publicKey, secret });
 
   return this;
 });

--- a/src/app/services/account.js
+++ b/src/app/services/account.js
@@ -48,16 +48,7 @@ app.factory('Account', function ($rootScope, $peers, $q) {
     return deferred.promise;
   };
 
-  this.sendLSK = (recipient, amount, passphrase, secondPassphrase) => {
-    const deferred = $q.defer();
-    $peers.active.sendLSK(recipient, amount, passphrase, secondPassphrase, (data) => {
-      if (data.success) {
-        return deferred.resolve(data);
-      }
-      return deferred.reject(data);
-    });
-    return deferred.promise;
-  };
+  this.sendLSK = (recipientId, amount, passphrase, secondPassphrase) => $peers.sendRequestPromise('transactions', { recipientId, amount, secret, secondSecret });
 
   this.listTransactions = (address, limit, offset) => $peers.sendRequestPromise('transactions', {
     senderId: address,
@@ -66,16 +57,7 @@ app.factory('Account', function ($rootScope, $peers, $q) {
     offset: offset || 0,
   });
 
-  this.setSignature = (secondSecret, publicKey, secret) => {
-    const deferred = $q.defer();
-    $peers.active.sendRequest('signatures', { secondSecret, publicKey, secret }, (res) => {
-      if (res.success) {
-        deferred.resolve(res);
-      }
-      deferred.reject(res);
-    });
-    return deferred.promise;
-  };
+  this.setSignature = (secondSecret, publicKey, secret) => $peers.sendRequestPromise('signatures', { secondSecret, publicKey, secret });
 
   return this;
 });

--- a/src/app/services/account.js
+++ b/src/app/services/account.js
@@ -58,7 +58,7 @@ app.factory('Account', function ($rootScope, $peers, $q) {
     offset,
   });
 
-  this.setSignature = (secondSecret, publicKey, secret) => $peers.sendRequestPromise(
+  this.setSecondSecret = (secondSecret, publicKey, secret) => $peers.sendRequestPromise(
     'signatures', { secondSecret, publicKey, secret });
 
   return this;

--- a/src/app/services/account.js
+++ b/src/app/services/account.js
@@ -1,6 +1,6 @@
 import lisk from 'lisk-js';
 
-app.factory('Account', function ($rootScope) {
+app.factory('Account', function ($rootScope, $peers, $q) {
   this.account = {};
 
   const merge = (obj) => {
@@ -15,7 +15,7 @@ app.factory('Account', function ($rootScope) {
       }
 
       // Calling listeners with the list of changes
-      $rootScope.$broadcast('onAccountChange', {});
+      $rootScope.$broadcast('onAccountChange', this.account);
     });
   };
 
@@ -31,6 +31,50 @@ app.factory('Account', function ($rootScope) {
     keys.forEach((key) => {
       delete this.account[key];
     });
+  };
+
+  this.getAccountPromise = (address) => {
+    const deferred = $q.defer();
+    $peers.active.getAccount(this.account.address, (data) => {
+      if (data.success) {
+        deferred.resolve(data.account);
+      } else {
+        deferred.resolve({
+          address,
+          balance: 0,
+        });
+      }
+    });
+    return deferred.promise;
+  };
+
+  this.sendLSK = (recipient, amount, passphrase, secondPassphrase) => {
+    const deferred = $q.defer();
+    $peers.active.sendLSK(recipient, amount, passphrase, secondPassphrase, (data) => {
+      if (data.success) {
+        return deferred.resolve(data);
+      }
+      return deferred.reject(data);
+    });
+    return deferred.promise;
+  };
+
+  this.listTransactions = (address, limit, offset) => $peers.sendRequestPromise('transactions', {
+    senderId: address,
+    recipientId: address,
+    limit: limit || 20,
+    offset: offset || 0,
+  });
+
+  this.setSignature = (secondSecret, publicKey, secret) => {
+    const deferred = $q.defer();
+    $peers.active.sendRequest('signatures', { secondSecret, publicKey, secret }, (res) => {
+      if (res.success) {
+        deferred.resolve(res);
+      }
+      deferred.reject(res);
+    });
+    return deferred.promise;
   };
 
   return this;

--- a/src/app/services/account.js
+++ b/src/app/services/account.js
@@ -51,11 +51,11 @@ app.factory('Account', function ($rootScope, $peers, $q) {
   this.sendLSK = (recipientId, amount, secret, secondSecret) => $peers.sendRequestPromise(
     'transactions', { recipientId, amount, secret, secondSecret });
 
-  this.listTransactions = (address, limit, offset) => $peers.sendRequestPromise('transactions', {
+  this.listTransactions = (address, limit = 20, offset = 0) => $peers.sendRequestPromise('transactions', {
     senderId: address,
     recipientId: address,
-    limit: limit || 20,
-    offset: offset || 0,
+    limit,
+    offset,
   });
 
   this.setSignature = (secondSecret, publicKey, secret) => $peers.sendRequestPromise(

--- a/src/app/services/peers/peers.js
+++ b/src/app/services/peers/peers.js
@@ -2,13 +2,13 @@ import lisk from 'lisk-js';
 
 const UPDATE_INTERVAL_CHECK = 10000;
 
-app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope, Account) => {
+app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope) => {
   class $peers {
     constructor() {
       this.check();
 
-      $rootScope.$on('onAccountChange', () => {
-        this.setActive();
+      $rootScope.$on('onAccountChange', (event, account) => {
+        this.setActive(account);
       });
     }
 
@@ -20,9 +20,9 @@ app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope, Account) =
       }
     }
 
-    setActive() {
+    setActive(account) {
       let conf = { };
-      const network = Account.get().network;
+      const network = account.network;
       if (network) {
         conf = network;
         if (network.address) {
@@ -35,7 +35,7 @@ app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope, Account) =
         }
       }
 
-      this.setPeerAPIObject(conf);
+      this.active = lisk.api(conf);
       this.check();
     }
 
@@ -50,56 +50,8 @@ app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope, Account) =
       return deferred.promise;
     }
 
-    listTransactions(address, limit, offset) {
-      return this.sendRequestPromise('transactions', {
-        senderId: address,
-        recipientId: address,
-        limit: limit || 20,
-        offset: offset || 0,
-      });
-    }
-
-    setPeerAPIObject(config) {
-      this.active = lisk.api(config);
-
-      this.active.getStatusPromise = () => this.sendRequestPromise('loader/status', {});
-
-      this.active.getAccountPromise = (address) => {
-        const deferred = $q.defer();
-        this.active.getAccount(address, (data) => {
-          if (data.success) {
-            deferred.resolve(data.account);
-          } else {
-            deferred.resolve({
-              address,
-              balance: 0,
-            });
-          }
-        });
-        return deferred.promise;
-      };
-
-      this.active.sendLSKPromise = (recipient, amount, passphrase, secondPassphrase) => {
-        const deferred = $q.defer();
-        this.active.sendLSK(recipient, amount, passphrase, secondPassphrase, (data) => {
-          if (data.success) {
-            return deferred.resolve(data);
-          }
-          return deferred.reject(data);
-        });
-        return deferred.promise;
-      };
-
-      this.active.setSignature = (secondSecret, publicKey, secret) => {
-        const deferred = $q.defer();
-        this.active.sendRequest('signatures', { secondSecret, publicKey, secret }, (res) => {
-          if (res.success) {
-            deferred.resolve(res);
-          }
-          deferred.reject(res);
-        });
-        return deferred.promise;
-      };
+    getStatusPromise() {
+      return this.sendRequestPromise('loader/status', {});
     }
 
     check() {
@@ -112,7 +64,7 @@ app.factory('$peers', ($timeout, $cookies, $location, $q, $rootScope, Account) =
         return;
       }
 
-      this.active.getStatusPromise()
+      this.getStatusPromise()
         .then(() => this.online = true)
         .catch(() => this.online = false)
         .finally(() => next());

--- a/src/app/services/sign-verify.js
+++ b/src/app/services/sign-verify.js
@@ -1,13 +1,6 @@
 app.factory('signVerify', ($mdDialog, $mdMedia) => ({
   openSignMessageDialog() {
     return $mdDialog.show({
-      controllerAs: '$ctrl',
-      controller: class signMessageDialog {
-        constructor($scope, Account) {
-          this.$scope = $scope;
-          this.account = Account;
-        }
-      },
       template:
           '<md-dialog flex="80">' +
             '<sign-message></sign-message>' +

--- a/src/test/components/main/main.spec.js
+++ b/src/test/components/main/main.spec.js
@@ -155,10 +155,9 @@ describe('main component controller', () => {
         balance: '0',
         passphrase: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
       });
-      controller.$peers.active = {
-        getAccountPromise() {
-          return deffered.promise;
-        },
+      const mock = sinon.mock(controller.account);
+      mock.expects('getAccountPromise').returns(deffered.promise);
+      controller.$peers = {
         getStatusPromise() {
           return $q.defer().promise;
         },
@@ -167,7 +166,7 @@ describe('main component controller', () => {
       account.reset();
     });
 
-    it('calls this.$peers.active.getAccountPromise(this.address) and then sets balance', () => {
+    it('calls this.account.getAccountPromise(this.address) and then sets balance', () => {
       expect(account.get().balance).to.equal(undefined);
       controller.update();
       deffered.resolve({ balance: 12345 });
@@ -175,7 +174,7 @@ describe('main component controller', () => {
       expect(account.get().balance).to.equal(12345);
     });
 
-    it('calls this.$peers.active.getAccountPromise(this.address) and if it fails, then resets this.account.balance and reject the promise that update() returns', () => {
+    it('calls this.account.getAccountPromise(this.address) and if it fails, then resets this.account.balance and reject the promise that update() returns', () => {
       const spy = sinon.spy(controller.$q, 'reject');
       controller.update();
       deffered.reject();

--- a/src/test/components/main/setSecondPassDirective.spec.js
+++ b/src/test/components/main/setSecondPassDirective.spec.js
@@ -41,7 +41,7 @@ describe('setSecondPass Directive', () => {
     it('listens for an onAfterSignup event', () => {
       const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('setSignature').returns(deffered.promise);
+      mock.expects('setSecondSecret').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'successAlert');
 
@@ -66,10 +66,10 @@ describe('setSecondPass Directive', () => {
   });
 
   describe('scope.passConfirmSubmit', () => {
-    it('should call account.setSignature', () => {
+    it('should call account.setSecondSecret', () => {
       const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('setSignature').returns(deffered.promise);
+      mock.expects('setSecondSecret').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'successAlert');
       $scope.passConfirmSubmit();
@@ -83,7 +83,7 @@ describe('setSecondPass Directive', () => {
     it('should show error dialog if trying to set second passphrase multiple times', () => {
       const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('setSignature').returns(deffered.promise);
+      mock.expects('setSecondSecret').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'errorAlert');
       $scope.passConfirmSubmit();
@@ -104,7 +104,7 @@ describe('setSecondPass Directive', () => {
     it('should show error dialog if account does not have enough LSK', () => {
       const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('setSignature').returns(deffered.promise);
+      mock.expects('setSecondSecret').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'errorAlert');
       $scope.passConfirmSubmit();
@@ -117,7 +117,7 @@ describe('setSecondPass Directive', () => {
     it('should show error dialog for all the other errors', () => {
       const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('setSignature').returns(deffered.promise);
+      mock.expects('setSecondSecret').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'errorAlert');
       $scope.passConfirmSubmit();

--- a/src/test/components/main/setSecondPassDirective.spec.js
+++ b/src/test/components/main/setSecondPassDirective.spec.js
@@ -10,7 +10,7 @@ describe('setSecondPass Directive', () => {
   let $scope;
   let $rootScope;
   let element;
-  let $peers;
+  let account;
   let setSecondPass;
   let $q;
   let dialog;
@@ -21,12 +21,12 @@ describe('setSecondPass Directive', () => {
 
     // Store references to $rootScope and $compile
     // so they are available to all tests in this describe block
-    inject((_$compile_, _$rootScope_, _setSecondPass_, _$peers_, _$q_, _dialog_) => {
+    inject((_$compile_, _$rootScope_, _setSecondPass_, _Account_, _$q_, _dialog_) => {
       // The injector unwraps the underscores (_) from around the parameter names when matching
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       setSecondPass = _setSecondPass_;
-      $peers = _$peers_;
+      account = _Account_;
       $q = _$q_;
       dialog = _dialog_;
       $scope = $rootScope.$new();
@@ -39,8 +39,7 @@ describe('setSecondPass Directive', () => {
 
   describe('SetSecondPassLink', () => {
     it('listens for an onAfterSignup event', () => {
-      $peers.active = { setSignature() {} };
-      const mock = sinon.mock($peers.active);
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
       mock.expects('setSignature').returns(deffered.promise);
 
@@ -67,9 +66,8 @@ describe('setSecondPass Directive', () => {
   });
 
   describe('scope.passConfirmSubmit', () => {
-    it('should call $peers.active.setSignature', () => {
-      $peers.active = { setSignature() {} };
-      const mock = sinon.mock($peers.active);
+    it('should call account.setSignature', () => {
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
       mock.expects('setSignature').returns(deffered.promise);
 
@@ -82,9 +80,8 @@ describe('setSecondPass Directive', () => {
       expect(spy).to.have.been.calledWith();
     });
 
-    it('should show error dialog if trying to set second passphrase mulpiple times', () => {
-      $peers.active = { setSignature() {} };
-      const mock = sinon.mock($peers.active);
+    it('should show error dialog if trying to set second passphrase multiple times', () => {
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
       mock.expects('setSignature').returns(deffered.promise);
 
@@ -105,8 +102,7 @@ describe('setSecondPass Directive', () => {
     });
 
     it('should show error dialog if account does not have enough LSK', () => {
-      $peers.active = { setSignature() {} };
-      const mock = sinon.mock($peers.active);
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
       mock.expects('setSignature').returns(deffered.promise);
 
@@ -119,8 +115,7 @@ describe('setSecondPass Directive', () => {
     });
 
     it('should show error dialog for all the other errors', () => {
-      $peers.active = { setSignature() {} };
-      const mock = sinon.mock($peers.active);
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
       mock.expects('setSignature').returns(deffered.promise);
 

--- a/src/test/components/send/send.spec.js
+++ b/src/test/components/send/send.spec.js
@@ -59,24 +59,21 @@ describe('Send component', () => {
   });
 
   describe('send transaction', () => {
-    let $q;
-    let $peers;
     let dialog;
+    let $q;
 
-    beforeEach(inject((_dialog_, _$q_, _$peers_) => {
+    beforeEach(inject((_dialog_, _$q_) => {
       dialog = _dialog_;
       $q = _$q_;
-      $peers = _$peers_;
     }));
 
     it('should allow to send a transaction', () => {
       const RECIPIENT_ADDRESS = '5932438298200837883L';
       const AMOUNT = '10';
 
-      $peers.active = { sendLSKPromise() {} };
-      const mock = sinon.mock($peers.active);
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('sendLSKPromise').returns(deffered.promise);
+      mock.expects('sendLSK').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'successAlert');
 
@@ -95,10 +92,9 @@ describe('Send component', () => {
       const RECIPIENT_ADDRESS = '5932438298200837883L';
       const AMOUNT = lsk.normalize(account.get().balance - 10000000);
 
-      $peers.active = { sendLSKPromise() {} };
-      const mock = sinon.mock($peers.active);
+      const mock = sinon.mock(account);
       const deffered = $q.defer();
-      mock.expects('sendLSKPromise').returns(deffered.promise);
+      mock.expects('sendLSK').returns(deffered.promise);
 
       const spy = sinon.spy(dialog, 'successAlert');
 
@@ -182,11 +178,10 @@ describe('send component controller', () => {
       expect(spy).to.have.been.calledWith();
     });
 
-    it('calls this.$peers.active.sendLSKPromise() and dialog.successAlert on success', () => {
-      controller.$peers = { active: { sendLSKPromise() {} } };
-      const mock = sinon.mock(controller.$peers.active);
+    it('calls this.account.sendLSK() and success.dialog on success', () => {
+      const mock = sinon.mock(controller.account);
       const deffered = $q.defer();
-      mock.expects('sendLSKPromise').returns(deffered.promise);
+      mock.expects('sendLSK').returns(deffered.promise);
       controller.go();
 
       const spy = sinon.spy(controller.dialog, 'successAlert');
@@ -197,11 +192,10 @@ describe('send component controller', () => {
       });
     });
 
-    it('calls this.$peers.active.sendLSKPromise() and error.dialog on error', () => {
-      controller.$peers = { active: { sendLSKPromise() {} } };
-      const mock = sinon.mock(controller.$peers.active);
+    it('calls this.account.sendLSK() and error.dialog on error', () => {
+      const mock = sinon.mock(controller.account);
       const deffered = $q.defer();
-      mock.expects('sendLSKPromise').returns(deffered.promise);
+      mock.expects('sendLSK').returns(deffered.promise);
       controller.go();
 
       const spy = sinon.spy(controller.dialog, 'errorAlert');

--- a/src/test/components/transactions/transactions.spec.js
+++ b/src/test/components/transactions/transactions.spec.js
@@ -14,19 +14,18 @@ describe('transactions component controller', () => {
   let controller;
   let $componentController;
   let account;
-  let $peers;
+  let mock;
 
-  beforeEach(inject((_$componentController_, _$rootScope_, _$q_, _Account_, _$peers_) => {
+  beforeEach(inject((_$componentController_, _$rootScope_, _$q_, _Account_) => {
     $componentController = _$componentController_;
     $rootScope = _$rootScope_;
     $q = _$q_;
     account = _Account_;
-    $peers = _$peers_;
   }));
 
   beforeEach(() => {
     $scope = $rootScope.$new();
-    const mock = sinon.mock($peers);
+    mock = sinon.mock(account);
     const deffered = $q.defer();
     mock.expects('listTransactions').returns(deffered.promise);
     mock.expects('listTransactions').returns(deffered.promise);
@@ -35,6 +34,11 @@ describe('transactions component controller', () => {
       passphrase: 'robust swift grocery peasant forget share enable convince deputy road keep cheap',
       balance: '0',
     });
+  });
+
+  afterEach(() => {
+    mock.verify();
+    mock.restore();
   });
 
   describe('$onDestroy()', () => {
@@ -54,46 +58,43 @@ describe('transactions component controller', () => {
   });
 
   describe('update(show, more)', () => {
-    let mock;
+    let transactionsDeferred;
 
     beforeEach(() => {
-      controller.$peers.listTransactions = () => {};
-      mock = sinon.mock(controller.$peers);
-      mock.expects('listTransactions').returns($q(() => {}));
+      transactionsDeferred = $q.defer();
     });
 
     it('sets this.loading = true', () => {
+      mock.expects('listTransactions').returns(transactionsDeferred.promise);
       controller.update();
       expect(controller.loading).to.equal(true);
     });
 
     it('sets this.loading_show = true if show == true', () => {
+      mock.expects('listTransactions').returns(transactionsDeferred.promise);
       controller.update(true);
       expect(controller.loading_show).to.equal(true);
     });
 
     it('doesn\'t change this.loading_show if show == false', () => {
+      mock.expects('listTransactions').returns(transactionsDeferred.promise);
       controller.update(false);
       expect(controller.loading_show).to.equal(undefined);
     });
 
     it('cancels update timeout', () => {
+      mock.expects('listTransactions').returns(transactionsDeferred.promise);
       const spy = sinon.spy(controller.$timeout, 'cancel');
       controller.update();
       expect(spy).to.have.been.calledWith(controller.timeout);
     });
 
-    it('calls this.$peers.listTransactions(account.get().address, limit) with limit = 10 by default', () => {
-      controller.$peers.listTransactions = () => {};
-      mock = sinon.mock(controller.$peers);
-      const transactionsDeferred = $q.defer();
+    it('calls this.account.listTransactions(account.get().address, limit) with limit = 10 by default', () => {
       mock.expects('listTransactions').withArgs(account.get().address, 10).returns(transactionsDeferred.promise);
       controller.update();
       transactionsDeferred.reject();
 
       $scope.$apply();
-      mock.verify();
-      mock.restore();
     });
   });
 
@@ -119,21 +120,17 @@ describe('transactions component controller', () => {
 
   describe('constructor()', () => {
     it('sets $watch on acount to run init()', () => {
-      const mock = sinon.mock(controller);
+      mock = sinon.mock(controller);
       mock.expects('init').withArgs();
       account.set({ balance: 1000 });
       $scope.$apply();
-      mock.verify();
-      mock.restore();
     });
 
     it('sets to run reset() and update() $on "peerUpdate" is $emited', () => {
-      const mock = sinon.mock(controller);
+      mock = sinon.mock(controller);
       mock.expects('reset').withArgs();
       mock.expects('update').withArgs(true);
       controller.$scope.$emit('peerUpdate');
-      mock.verify();
-      mock.restore();
     });
   });
 });

--- a/src/test/services/account.spec.js
+++ b/src/test/services/account.spec.js
@@ -64,7 +64,7 @@ describe('Factory: Account', () => {
     });
   });
 
-  describe('setSignature(secondSecret, publicKey, secret)', () => {
+  describe('setSecondSecret(secondSecret, publicKey, secret)', () => {
     it('returns $peers.sendRequestPromise(\'signatures\', { secondSecret, publicKey, secret });', () => {
       const publicKey = '3ff32442bb6da7d60c1b7752b24e6467813c9b698e0f278d48c43580da972135';
       const secret = 'wagon stock borrow episode laundry kitten salute link globe zero feed marble';
@@ -73,7 +73,7 @@ describe('Factory: Account', () => {
         .withArgs('signatures', { secondSecret, publicKey, secret })
         .returns(deffered.promise);
 
-      const promise = account.setSignature(secondSecret, publicKey, secret);
+      const promise = account.setSecondSecret(secondSecret, publicKey, secret);
 
       expect(promise).to.equal(deffered.promise);
     });

--- a/src/test/services/account.spec.js
+++ b/src/test/services/account.spec.js
@@ -1,0 +1,82 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('Factory: Account', () => {
+  let $peers;
+  let $q;
+  let account;
+  let mock;
+  let deffered;
+
+  beforeEach(angular.mock.module('app'));
+
+  beforeEach(inject((_$peers_, _$q_, Account) => {
+    $peers = _$peers_;
+    $q = _$q_;
+    account = Account;
+  }));
+
+  beforeEach(() => {
+    deffered = $q.defer();
+    mock = sinon.mock($peers);
+  });
+
+  afterEach(() => {
+    mock.verify();
+    mock.restore();
+  });
+
+  describe('sendLSK(recipientId, amount, secret, secondSecret)', () => {
+    it('returns $peers.sendRequestPromise(\'transactions\', options);', () => {
+      const options = {
+        recipientId: '537318935439898807L',
+        amount: 10,
+        secret: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
+        secondSecret: null,
+      };
+      mock.expects('sendRequestPromise').withArgs('transactions', options).returns(deffered.promise);
+
+      const promise = account.sendLSK(
+        options.recipientId, options.amount, options.secret, options.secondSecret);
+
+      expect(promise).to.equal(deffered.promise);
+    });
+  });
+
+  describe('listTransactions(address, limit, offset)', () => {
+    it('returns $peers.sendRequestPromise(\'transactions\', options);', () => {
+      const options = {
+        senderId: '537318935439898807L',
+        recipientId: '537318935439898807L',
+        limit: 20,
+        offset: 0,
+      };
+      mock.expects('sendRequestPromise').withArgs('transactions', options).returns(deffered.promise);
+
+      const promise = account.listTransactions(
+        options.recipientId, options.limit, options.offset);
+
+      expect(promise).to.equal(deffered.promise);
+    });
+  });
+
+  describe('setSignature(secondSecret, publicKey, secret)', () => {
+    it('returns $peers.sendRequestPromise(\'signatures\', { secondSecret, publicKey, secret });', () => {
+      const publicKey = '3ff32442bb6da7d60c1b7752b24e6467813c9b698e0f278d48c43580da972135';
+      const secret = 'wagon stock borrow episode laundry kitten salute link globe zero feed marble';
+      const secondSecret = 'stay undo beyond powder sand laptop grow gloom apology hamster primary arrive';
+      mock.expects('sendRequestPromise')
+        .withArgs('signatures', { secondSecret, publicKey, secret })
+        .returns(deffered.promise);
+
+      const promise = account.setSignature(secondSecret, publicKey, secret);
+
+      expect(promise).to.equal(deffered.promise);
+    });
+  });
+});
+

--- a/src/test/services/peers/peers.spec.js
+++ b/src/test/services/peers/peers.spec.js
@@ -18,58 +18,17 @@ describe('Factory: $peers', () => {
     $rootScope = _$rootScope_;
   }));
 
-  describe('setActive()', () => {
+  describe('setActive(account)', () => {
     it('sets $peers.active to a random active official peer', () => {
+      const account = {
+        network: {
+          address: 'http://localhost:8000',
+        },
+      };
       expect($peers.active).to.equal(undefined);
-      $peers.setActive();
+      $peers.setActive(account);
       expect($peers.active).not.to.equal(undefined);
       expect($peers.active.currentPeer).not.to.equal(undefined);
-    });
-  });
-
-  describe('setPeerAPIObject', () => {
-    const RECIPIENT_ADDRESS = '5932438298200837883L';
-    const AMOUNT = '10';
-    const PASSPHRASE = 'robust swift grocery peasant forget share enable convince deputy road keep cheap';
-
-    beforeEach(() => {
-      $peers.setActive();
-      $peers.setPeerAPIObject({
-        node: 'localhost',
-        port: 4000,
-        testnet: true,
-        nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-      });
-    });
-
-    it('sets getter/setter methods on $peers.active if it\'s called with correct configs', () => {
-      expect($peers.active.getStatusPromise).not.to.equal(undefined);
-      expect($peers.active.getAccountPromise).not.to.equal(undefined);
-      expect($peers.active.sendLSKPromise).not.to.equal(undefined);
-    });
-
-    it('creates $peers.active.getStatusPromise which returns a promise', () => {
-      const promise = $peers.active.getStatusPromise();
-      $rootScope.$apply();
-      expect(promise.then.constructor).to.be.equal(Function);
-    });
-
-    it('creates $peers.active.getAccountPromise which returns a promise', () => {
-      const promise = $peers.active.getAccountPromise(RECIPIENT_ADDRESS);
-      $rootScope.$apply();
-      expect(promise.then.constructor).to.be.equal(Function);
-    });
-
-    it('creates $peers.active.sendLSKPromise which returns a promise', () => {
-      const promise = $peers.active.sendLSKPromise(RECIPIENT_ADDRESS, AMOUNT, PASSPHRASE);
-      $rootScope.$apply();
-      expect(promise.then.constructor).to.be.equal(Function);
-    });
-
-    it.skip('creates $peers.active.listTransactionsPromise which returns a promise', () => {
-      const promise = $peers.active.listTransactionsPromise(RECIPIENT_ADDRESS, AMOUNT);
-      $rootScope.$apply();
-      expect(promise.then.constructor).to.be.equal(Function);
     });
   });
 
@@ -79,16 +38,9 @@ describe('Factory: $peers', () => {
 
     beforeEach(() => {
       deffered = $q.defer();
-      $peers.active = {
-        getAccountPromise() {
-          return deffered.promise;
-        },
-        getStatusPromise() {
-          return $q.defer().promise;
-        },
-      };
-      mock = sinon.mock($peers.active);
-      mock.expects('getStatusPromise').withArgs().returns(deffered.promise);
+      mock = sinon.mock($peers);
+      mock.expects('getStatusPromise').returns(deffered.promise);
+      $peers.active = {};
     });
 
     afterEach(() => {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -14,6 +14,7 @@ require('./components/transactions/transactions.spec');
 require('./components/sign-verify/sign-message.spec');
 require('./components/sign-verify/verify-message.spec');
 
+require('./services/account.spec');
 require('./services/peers/peers.spec');
 require('./services/passphrase.spec');
 require('./services/sign-verify.spec');


### PR DESCRIPTION
### Expected behaviour
peers service should contain only code related to setting and maintaining a connection to a peer.

### Actual behaviour
peers service contains definitions of the following methods that result in a server call:
- listTransactions
- getStatusPromise
- sendLSKPromise
- listTransactionsPromise
- setSignature

All of them are related to an account, so they should be moved to another service: account

Closes #169


