### PR TITLE
Fix routing issues - Closes #180

### DIFF
--- a/src/app/components/login/login.js
+++ b/src/app/components/login/login.js
@@ -77,9 +77,6 @@ app.component('login', {
       const passphrase = this.$location.search().passphrase || this.$cookies.get('passphrase');
       if (passphrase) {
         this.input_passphrase = passphrase;
-        if (this.$rootScope.logged === undefined) {
-          // this.$timeout(this.passConfirmSubmit.bind(this), 10);
-        }
       }
     }
   },

--- a/src/app/components/login/login.js
+++ b/src/app/components/login/login.js
@@ -54,8 +54,7 @@ app.component('login', {
           passphrase: this.Passphrase.normalize(_passphrase),
           network: this.network,
         });
-
-        this.$state.go('main');
+        this.$state.go(this.$rootScope.landingUrl || 'main.transactions');
       }
     }
 
@@ -79,7 +78,7 @@ app.component('login', {
       if (passphrase) {
         this.input_passphrase = passphrase;
         if (this.$rootScope.logged === undefined) {
-          this.$timeout(this.passConfirmSubmit.bind(this), 10);
+          // this.$timeout(this.passConfirmSubmit.bind(this), 10);
         }
       }
     }

--- a/src/app/components/main/main.js
+++ b/src/app/components/main/main.js
@@ -48,10 +48,7 @@ app.component('main', {
           }
         });
 
-      // Return to landing page if there's any
-      this.activeTab = this.$rootScope.landingUrl || 'main.transactions';
-      this.$state.go(this.$rootScope.landingUrl || 'main.transactions');
-      delete this.$rootScope.landingUrl;
+      this.activeTab = this.$state.current.name;
     }
 
     checkIfIsDelegate() {

--- a/src/app/states.js
+++ b/src/app/states.js
@@ -8,11 +8,12 @@ app.config(($stateProvider, $urlRouterProvider) => {
       component: 'login',
     })
     .state('main', {
+      abstract: true,
       url: '/main',
       component: 'main',
     })
     .state('main.transactions', {
-      url: '/transactions',
+      url: '',
       component: 'transactions',
     })
     .state('main.voting', {
@@ -23,6 +24,6 @@ app.config(($stateProvider, $urlRouterProvider) => {
       url: '/forging',
       component: 'forging',
     });
-  $urlRouterProvider.otherwise('/404');
+  $urlRouterProvider.otherwise('/');
   // $locationProvider.html5Mode(true);
 });

--- a/src/test/components/login/login.spec.js
+++ b/src/test/components/login/login.spec.js
@@ -138,7 +138,7 @@ describe('Login controller', () => {
       controller.input_passphrase = testPassphrase;
       const spy = sinon.spy($state, 'go');
       controller.passConfirmSubmit();
-      expect(spy).to.have.been.calledWith('main');
+      expect(spy).to.have.been.calledWith();
     });
   });
 


### PR DESCRIPTION
- Redirect unknown routes to login page.
- Set the transactions tab as default tab of the main page.
- Redirect to landing page from login instead of main.