### PR TITLE
Fix transaction list order

### DIFF
--- a/src/services/api/accountApi.js
+++ b/src/services/api/accountApi.js
@@ -59,12 +59,14 @@ app.factory('AccountApi', function ($q, Peers, Account) {
    * @param {String} address - The address of the account to get transactions list for
    * @param {Number} [limit = 20] - The maximum number of items in list
    * @param {Number} [offset = 0] - The offset index
+   * @param {String} [orderBy = 'timestamp:desc'] - How is the list ordered
    */
-  this.transactions.get = (address, limit = 20, offset = 0) => Peers.sendRequestPromise('transactions', {
+  this.transactions.get = (address, limit = 20, offset = 0, orderBy = 'timestamp:desc') => Peers.sendRequestPromise('transactions', {
     senderId: address,
     recipientId: address,
     limit,
     offset,
+    orderBy,
   });
 
   return this;

--- a/test/services/api/accountApi.spec.js
+++ b/test/services/api/accountApi.spec.js
@@ -46,13 +46,14 @@ describe('Factory: AccountApi', () => {
     });
   });
 
-  describe('transaction.get(address, limit, offset)', () => {
+  describe('transaction.get(address, limit, offset, orderBy)', () => {
     it('returns Peers.sendRequest(\'transactions\', options);', () => {
       const options = {
         senderId: '537318935439898807L',
         recipientId: '537318935439898807L',
         limit: 20,
         offset: 0,
+        orderBy: 'timestamp:desc',
       };
 
       const spy = sinon.spy(peers, 'sendRequestPromise');


### PR DESCRIPTION
We forgot to send oderBy param, because previously lisk-js api function
call was sending it implicitly