### PR TITLE
Add "Load more" button back to transactions list - Closes #256

### DIFF
--- a/src/components/transactions/transactions.pug
+++ b/src/components/transactions/transactions.pug
@@ -47,5 +47,6 @@ md-card.offline-hide
               td(md-cell)
                 .fee
                   lsk(amount='transaction.fee')
+      md-button.more-button(ng-show='$ctrl.moreTransactionsExist', ng-disabled='!$ctrl.loaded', ng-click='$ctrl.showMore()') Load More
   .loading
     md-progress-linear(md-mode='indeterminate', ng-show='!$ctrl.loaded')


### PR DESCRIPTION
Because in the electron wrapper we newer open the window fullscreen:

https://github.com/LiskHQ/lisk-nano/blob/development/app/main.js#L13

So mostly infinite scroll will just work. And on the rare case that user resizes the window, they'll just have to click a button, and we will save some server requests.

Closes #256