### PR TITLE
Change delegate registration modal header text - Closes #345

### DIFF
--- a/src/components/delegateRegistration/delegateRegistration.pug
+++ b/src/components/delegateRegistration/delegateRegistration.pug
@@ -2,7 +2,7 @@ div.dialog-delegate-registration(aria-label='Vote for delegates')
   form(name='delegateRegistrationForm', ng-submit='form.onSubmit(delegateRegistrationForm)')
     md-toolbar
       .md-toolbar-tools
-        h2 Delegate Registration
+        h2 Register as delegate
         span(flex='')
         md-button.md-icon-button(ng-click='cancel(delegateRegistrationForm)', aria-label='Close dialog')
           i.material-icons close


### PR DESCRIPTION
The text of header of delegateRegistration component is changed to "Register as delegate" .
