### PR TITLE
Use <a> element to parse url instead of Regexp

### DIFF
--- a/src/services/api/peers.js
+++ b/src/services/api/peers.js
@@ -1,5 +1,5 @@
 import lisk from 'lisk-js';
-
+import urlParser from '../../util/urlParser';
 /**
  * This factory provides methods for communicating with peers. It exposes
  * sendRequestPromise method for requesting to available endpoint to the active peer,
@@ -54,9 +54,10 @@ app.factory('Peers', ($timeout, $cookies, $location, $q, $rootScope, dialog) => 
       if (network) {
         conf = network;
         if (network.address) {
-          conf.node = network.address.split(':')[1].replace('//', '');
-          conf.port = network.address.match(/:([0-9]{1,5})\/?$/) && network.address.match(/:([0-9]{1,5})\/?$/)[1];
-          conf.ssl = network.address.split(':')[0] === 'https';
+          const { hostname, port, protocol } = urlParser(network.address);
+          conf.node = hostname;
+          conf.port = port;
+          conf.ssl = protocol === 'https:';
         }
         if (conf.testnet === undefined && conf.port !== undefined) {
           conf.testnet = conf.port === '7000';

--- a/src/util/urlParser.js
+++ b/src/util/urlParser.js
@@ -1,0 +1,6 @@
+export default function (url) {
+  const link = document.createElement('a');
+  link.href = url;
+  return link;
+}
+


### PR DESCRIPTION
There an error when parsing the wrong URL with regexp.
fix #417 