### PR TITLE
Invalid timestamp fixes - Closes #365

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "debug": "=2.2.0",
     "jasmine-spec-reporter": "=3.3.0",
     "jquery": "=2.2.4",
-    "lisk-js": "=0.4.2",
+    "lisk-js": "=0.4.4",
     "lodash": "=4.16.4",
     "moment": "=2.15.1",
     "ng-infinite-scroll": "=1.3.0",

--- a/src/services/api/accountApi.js
+++ b/src/services/api/accountApi.js
@@ -35,9 +35,11 @@ app.factory('AccountApi', function ($q, Peers, Account) {
    * @param {String} publicKey - Account publicKey
    * @param {String} secret - Account primary passphrase
    * @returns {promise} Api call promise
+   * @param {Number} [timestamp = 10] - The time offset to compensate time setting issues
    */
-  this.setSecondSecret = (secondSecret, publicKey, secret) => Peers.sendRequestPromise(
-    'signatures', { secondSecret, publicKey, secret });
+  this.setSecondSecret = (secondSecret, publicKey,
+    secret, timestamp = 10) => Peers.sendRequestPromise(
+    'signatures', { secondSecret, publicKey, secret, timestamp });
 
   this.transactions = {};
 
@@ -48,10 +50,11 @@ app.factory('AccountApi', function ($q, Peers, Account) {
    * @param {Number} amount - A floating point value in LSK
    * @param {String} secret - account's primary passphrase
    * @param {String} [secondSecret = null] - The second passphrase of the account (if enabled).
+   * @param {Number} [timestamp = 10] - The time offset to compensate time setting issues
    */
   this.transactions.create = (recipientId, amount, secret,
-    secondSecret = null) => Peers.sendRequestPromise('transactions',
-      { recipientId, amount, secret, secondSecret });
+    secondSecret = null, timestamp = 10) => Peers.sendRequestPromise('transactions',
+      { recipientId, amount, secret, secondSecret, timestamp });
 
   /**
    * Uses Peers service to get the list of transactions for a specific address

--- a/src/services/api/delegateApi.js
+++ b/src/services/api/delegateApi.js
@@ -35,11 +35,13 @@ app.factory('delegateApi', Peers => ({
    * @param {array} unvoteList  - The list of the delegates from whom we're removing our votes
    * @param {String} [secondSecret=null]
    * @returns {promise} Api call promise
+   * @param {Number} [timestamp = 10] - The time offset to compensate time setting issues
    */
-  vote(secret, publicKey, voteList, unvoteList, secondSecret = null) {
+  vote(secret, publicKey, voteList, unvoteList, secondSecret = null, timestamp = 10) {
     return Peers.sendRequestPromise('accounts/delegates', {
       secret,
       publicKey,
+      timestamp,
       delegates: voteList.map(delegate => `+${delegate.publicKey}`).concat(
         unvoteList.map(delegate => `-${delegate.publicKey}`),
       ),
@@ -79,9 +81,10 @@ app.factory('delegateApi', Peers => ({
    * @param {String} secret - Account primary passphrase
    * @param {String} [secondSecret = null] - The second passphrase of the account (if enabled).
    * @returns {promise} Api call promise
+   * @param {Number} [timestamp = 10] - The time offset to compensate time setting issues
    */
-  registerDelegate(username, secret, secondSecret = null) {
-    const data = { username, secret };
+  registerDelegate(username, secret, secondSecret = null, timestamp = 10) {
+    const data = { username, secret, timestamp };
     if (secondSecret) {
       data.secondSecret = secondSecret;
     }

--- a/test/services/api/accountApi.spec.js
+++ b/test/services/api/accountApi.spec.js
@@ -34,13 +34,15 @@ describe('Factory: AccountApi', () => {
       const options = {
         recipientId: '537318935439898807L',
         amount: 10,
+        timestamp: 10,
         secret: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
         secondSecret: null,
       };
       const spy = sinon.spy(peers, 'sendRequestPromise');
 
       accountApi.transactions.create(
-        options.recipientId, options.amount, options.secret, options.secondSecret);
+        options.recipientId, options.amount, options.secret,
+        options.secondSecret, options.timestamp);
 
       expect(spy).to.have.been.calledWith('transactions', options);
     });
@@ -72,10 +74,11 @@ describe('Factory: AccountApi', () => {
       const secondSecret = 'stay undo beyond powder sand laptop grow gloom apology hamster primary arrive';
 
       const spy = sinon.spy(peers, 'sendRequestPromise');
+      const timestamp = 10;
 
-      accountApi.setSecondSecret(secondSecret, publicKey, secret);
+      accountApi.setSecondSecret(secondSecret, publicKey, secret, timestamp);
 
-      expect(spy).to.have.been.calledWith('signatures', { secondSecret, publicKey, secret });
+      expect(spy).to.have.been.calledWith('signatures', { secondSecret, publicKey, secret, timestamp });
     });
   });
 });


### PR DESCRIPTION
- upgrades `lisk-js` to v0.4.4
- Adds `offsetSeconds` parameter to `transaction.crease` Api (default: 10).
Closes #365 
