### PR TITLE
Fix passphrase field - Closes #524

### DIFF
--- a/src/components/login/loginFormComponent.js
+++ b/src/components/login/loginFormComponent.js
@@ -91,7 +91,7 @@ class LoginFormComponent extends React.Component {
     setTimeout(() => {
       // get account info
       const { onAccountUpdated } = this.props;
-      onAccountUpdated({ passphrase: (passphrase || this.state.passphrase) });
+      onAccountUpdated({ passphrase });
       const accountInfo = this.props.account;
 
       // redirect to main/transactions
@@ -154,7 +154,8 @@ class LoginFormComponent extends React.Component {
                   onPassGenerated: this.onLoginSubmission.bind(this),
                 },
               })} />
-            <Button label='LOGIN' primary raised onClick={this.onLoginSubmission.bind(this)}
+            <Button label='LOGIN' primary raised
+              onClick={this.onLoginSubmission.bind(this, this.state.passphrase)}
               disabled={(this.state.network === 2 && this.state.addressValidity !== '') ||
               this.state.passphraseValidity !== ''} />
           </div>


### PR DESCRIPTION
The problem was that `onLoginSubmission` was getting the `event` param from `onClick` and tried to use it as `passphrase`.

Closes #524