### PR TITLE
Cleanup unit test output - Closes #578 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,6 +38,8 @@ module.exports = function (config) {
     autoWatch: false,
     browsers: ['Chrome'],
     singleRun: true,
+    browserNoActivityTimeout: 60000,
+    browserDisconnectTolerance: 3,
     concurrency: Infinity,
   });
 };

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "react-animate-on-change": "^1.0.0",
     "react-circular-progressbar": "=0.1.5",
     "react-dom": "=15.6.x",
-    "react-redux": "=5.0.3",
-    "react-router-dom": "=4.0.0",
+    "react-redux": "=5.0.5",
+    "react-router-dom": "=4.1.2",
     "react-toolbox": "=2.0.0-beta.12",
     "redux": "=3.6.0",
     "redux-logger": "=3.0.6"


### PR DESCRIPTION
- Updated `react-redux` and `react-router-dom` because previous versions use `PropTypes` from `React` library but not from `prop-type`
- Added `browserNoActivityTimeout` to `Karma` config, because without warnings messages about propTypes Karma close connection after 10000ms of waiting.
closes #578   