### PR TITLE
Display correct rank rate

### DIFF
--- a/src/components/forging/delegateStats.js
+++ b/src/components/forging/delegateStats.js
@@ -37,7 +37,9 @@ const DelegateStats = props => (
               <div className={style.circularProgressTitle}> {cardItem.label} </div>
               <CircularProgressbar
                 percentage={cardItem.percentageTransform(props.delegate[cardItem.key])}
-                textForPercentage={cardItem.textForPercentage.bind(props.delegate[cardItem.key])}/>
+                textForPercentage={
+                  cardItem.textForPercentage.bind(null, props.delegate[cardItem.key])
+                }/>
             </div>
           </div>
           </CardText>


### PR DESCRIPTION
**Before**:
![screen shot 2017-08-21 at 17 32 11](https://user-images.githubusercontent.com/922338/29523791-cee0b54e-8696-11e7-8285-a96843ae2c96.png)
**After**:
![screen shot 2017-08-21 at 17 31 24](https://user-images.githubusercontent.com/922338/29523803-d4e31fae-8696-11e7-9f0a-852df471f632.png)