### PR TITLE
Set up source maps in karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
       { pattern: filePattern, included: false, served: false, watched: false },
     ],
     preprocessors: {
+      '**/*.js': ['sourcemap'],
       [fileRoot]: ['webpack'],
     },
     reporters: ['coverage', 'mocha'],

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "karma-jenkins-reporter": "0.0.2",
     "karma-mocha": "=1.3.0",
     "karma-mocha-reporter": "=2.2.3",
+    "karma-sourcemap-loader": "=0.3.7",
     "karma-verbose-reporter": "=0.0.6",
     "karma-webpack": "=2.0.3",
     "mocha": "=3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = (env) => {
       path: path.resolve(__dirname, 'app', 'dist'),
       filename: env.test ? 'bundle.js' : 'bundle.[name].js',
     },
-    devtool: 'source-map',
+    devtool: env.test ? 'inline-source-map' : 'source-map',
     devServer: {
       contentBase: 'src',
       inline: true,


### PR DESCRIPTION
To make karma tell us where errors happened, like:
```
 (webpack:///src/components/offlineWrapper/index.test.js:32:19 <- src/tests.js:210776:31) 
``` 
instead of
```
 (src/tests.js:210776:31) 
``` 
