### PR TITLE
Fix pluralization for confirmation tooltip

### DIFF
--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -15,7 +15,7 @@ const TransactionRow = props => (
           <Spinner />}
     </td>
     <td className={`${props.tableStyle.rowCell} ${styles.centerText} ${styles.hiddenXs}`}>
-        <TooltipWrapper tooltip={`${props.value.confirmations} confirmations`}>{props.value.id}</TooltipWrapper>
+        <TooltipWrapper tooltip={`${props.value.confirmations} confirmation${props.value.confirmations !== 1 ? 's' : ''}`}>{props.value.id}</TooltipWrapper>
     </td>
     <td className={`${props.tableStyle.rowCell} ${styles.centerText}`}>
       <TransactionType {...props.value} address={props.address}></TransactionType>


### PR DESCRIPTION
This is the tiniest of tiny issues, but I was checking a transaction earlier and noticed that it said

> 1 confirmations 

Attention to little details is important 😄 