### PR TITLE
After-migration fixes in passphrase component - Closes #566

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -32,12 +32,11 @@ Feature: Login page
     Then I should be logged in
     And I should see text "Testnet" in "peer network" element
 
-  @ignore
   Scenario: should allow to create a new account
     Given I'm on login page
     When I click "new account button"
-    And I click on "next button"
+    And I click "next button"
     And I 250 times move mouse randomly
-    And I remember passphrase, click "yes its save button", fill in missing word
-    And I click "ok button"
+    And I remember passphrase, click "next button", fill in missing word
+    And I click "next button"
     Then I should be logged in

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -1,12 +1,11 @@
 Feature: Top right menu
-  @ignore
   Scenario: should allow to set 2nd passphrase
     Given I'm logged in as "second passphrase candidate"
     When I click "register second passphrase" in main menu
     And I click "next button"
     And I 250 times move mouse randomly
-    And I remember passphrase, click "yes its save button", fill in missing word
-    And I click "ok button"
+    And I remember passphrase, click "next button", fill in missing word
+    And I click "next button"
     Then I should see alert dialog with title "Success" and text "Second passphrase registration was successfully submitted. It can take several seconds before it is processed."
 
   Scenario: should not allow to set 2nd passphrase again

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -129,20 +129,20 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
   });
 
   When('I remember passphrase, click "{nextButtonSelector}", fill in missing word', (nextButtonSelector, callback) => {
-    waitForElemAndCheckItsText('save-passphrase h2', 'Save your passphrase in a safe place!');
+    waitForElemAndCheckItsText('.passphrase label', 'Save your passphrase in a safe place!');
 
-    element(by.css('save-passphrase textarea.passphrase')).getText().then((passphrase) => {
+    element(by.css('.passphrase textarea')).getText().then((passphrase) => {
       // eslint-disable-next-line no-unused-expressions
       expect(passphrase).to.not.be.undefined;
       const passphraseWords = passphrase.split(' ');
       expect(passphraseWords.length).to.equal(12);
       waitForElemAndClickIt(`.${nextButtonSelector.replace(/ /g, '-')}`);
 
-      element.all(by.css('save-passphrase p.passphrase span')).get(0).getText().then((firstPartOfPassphrase) => {
+      element.all(by.css('.passphrase-verifier p span')).get(0).getText().then((firstPartOfPassphrase) => {
         const missingWordIndex = firstPartOfPassphrase.length ?
           firstPartOfPassphrase.split(' ').length :
           0;
-        element(by.css('save-passphrase input')).sendKeys(passphraseWords[missingWordIndex]).then(callback);
+        element(by.css('.passphrase-verifier input')).sendKeys(passphraseWords[missingWordIndex]).then(callback);
       });
     });
   });

--- a/src/components/passphrase/passphrase.js
+++ b/src/components/passphrase/passphrase.js
@@ -43,8 +43,9 @@ class Passphrase extends React.Component {
     templates.generate = <PassphraseGenerator
       changeHandler={this.changeHandler.bind(this)} />;
 
-    // step 3: Confirmation, Asks for a random word to make sure the user has copied the passphrase
-    templates.show = <Input type='text' multiline label='Passphrase'
+    // step 3: Confirmation, shows the generated passphrase for user to save it
+    templates.show = <Input type='text' multiline autoFocus={true}
+      label='Save your passphrase in a safe place'
       value={this.state.passphrase} />;
 
     // step 4: Verification, Asks for a random word to make sure the user has copied the passphrase

--- a/src/components/passphrase/passphrase.js
+++ b/src/components/passphrase/passphrase.js
@@ -56,7 +56,7 @@ class Passphrase extends React.Component {
 
     return (
       <div>
-        <section className={`${styles.templateItem} ${grid['middle-xs']}`}>
+        <section className={`${styles.templateItem} ${grid.row} ${grid['middle-xs']}`}>
           <div className={grid['col-xs-12']}>
             { templates[current] }
           </div>

--- a/src/components/passphrase/passphrase.js
+++ b/src/components/passphrase/passphrase.js
@@ -45,6 +45,7 @@ class Passphrase extends React.Component {
 
     // step 3: Confirmation, shows the generated passphrase for user to save it
     templates.show = <Input type='text' multiline autoFocus={true}
+      className='passphrase'
       label='Save your passphrase in a safe place'
       value={this.state.passphrase} />;
 

--- a/src/components/passphrase/passphraseGenerator.js
+++ b/src/components/passphrase/passphraseGenerator.js
@@ -26,6 +26,12 @@ class PassphraseGenerator extends React.Component {
       zeroSeed: emptyByte('00'),
       seedDiff: emptyByte(0),
     };
+    this.seedGeneratorBoundToThis = this.seedGenerator.bind(this);
+    document.addEventListener('mousemove', this.seedGeneratorBoundToThis, true);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.seedGeneratorBoundToThis, true);
   }
 
   seedGenerator({ nativeEvent }) {
@@ -62,7 +68,7 @@ class PassphraseGenerator extends React.Component {
 
   render() {
     return (
-      <div className={`${grid.row} ${grid['center-xs']}`} onMouseMove={this.seedGenerator.bind(this)}>
+      <div className={`${grid.row} ${grid['center-xs']}`} >
         <div className={grid['col-xs-12']}>
           <p>Move your mouse to generate random bytes</p>
         </div>

--- a/src/components/passphrase/passphraseGenerator.js
+++ b/src/components/passphrase/passphraseGenerator.js
@@ -23,11 +23,11 @@ const isTouchDevice = (agent) => {
 
 const Byte = props => (
   <AnimateOnChange
-      animate={props.diff}
-      baseClassName={styles.stable}
-      animationClassName={styles.bouncing}>
-      <span className={styles.byte}>{ props.value }</span>
-    </AnimateOnChange>
+    animate={props.diff}
+    baseClassName={styles.stable}
+    animationClassName={styles.bouncing}>
+    <span className={styles.byte}>{ props.value }</span>
+  </AnimateOnChange>
 );
 
 class PassphraseGenerator extends React.Component {

--- a/src/components/passphrase/passphraseGenerator.js
+++ b/src/components/passphrase/passphraseGenerator.js
@@ -6,20 +6,6 @@ import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import { generateSeed, generatePassphrase, emptyByte } from '../../utils/passphrase';
 import styles from './passphrase.css';
 
-/**
- * Tests useragent with a regexp and defines if the account is mobile device
- *
- * @param {String} [agent] - The useragent string, This parameter is used for
- *  unit testing purpose
- * @returns {Boolean} - whether the agent represents a mobile device or not
- */
-const isTouchDevice = (agent) => {
-  let check = false;
-  if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(agent || navigator.userAgent || navigator.vendor || window.opera)) {
-    check = true;
-  }
-  return check;
-};
 
 const Byte = props => (
   <AnimateOnChange
@@ -48,6 +34,19 @@ class PassphraseGenerator extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('mousemove', this.seedGeneratorBoundToThis, true);
+  }
+
+  /**
+   * Tests useragent with a regexp and defines if the account is mobile device
+   *
+   * @param {String} [agent] - The useragent string, This parameter is used for
+   *  unit testing purpose
+   * @returns {Boolean} - whether the agent represents a mobile device or not
+   */
+  // it is on class so that we can mock it in unit tests
+  // eslint-disable-next-line class-methods-use-this
+  isTouchDevice(agent) {
+    return (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(agent || navigator.userAgent || navigator.vendor || window.opera));
   }
 
   seedGenerator(nativeEvent) {
@@ -92,11 +91,11 @@ class PassphraseGenerator extends React.Component {
     return (
       <div className={`${grid.row} ${grid['center-xs']}`} >
         <div className={grid['col-xs-12']}>
-          {isTouchDevice() ?
+          {this.isTouchDevice() ?
             <div>
               <p>Enter text below to generate random bytes</p>
               <Input onChange={this.seedGeneratorBoundToThis}
-                autoFocus={true} multiline={true} />
+                className='touch-fallback' autoFocus={true} multiline={true} />
             </div> :
             <p>Move your mouse to generate random bytes</p>
           }

--- a/src/components/passphrase/passphraseGenerator.js
+++ b/src/components/passphrase/passphraseGenerator.js
@@ -1,9 +1,25 @@
 import React from 'react';
 import AnimateOnChange from 'react-animate-on-change';
 import ProgressBar from 'react-toolbox/lib/progress_bar';
+import Input from 'react-toolbox/lib/input';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import { generateSeed, generatePassphrase, emptyByte } from '../../utils/passphrase';
 import styles from './passphrase.css';
+
+/**
+ * Tests useragent with a regexp and defines if the account is mobile device
+ *
+ * @param {String} [agent] - The useragent string, This parameter is used for
+ *  unit testing purpose
+ * @returns {Boolean} - whether the agent represents a mobile device or not
+ */
+const isTouchDevice = (agent) => {
+  let check = false;
+  if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(agent || navigator.userAgent || navigator.vendor || window.opera)) {
+    check = true;
+  }
+  return check;
+};
 
 const Byte = props => (
   <AnimateOnChange
@@ -34,12 +50,18 @@ class PassphraseGenerator extends React.Component {
     document.removeEventListener('mousemove', this.seedGeneratorBoundToThis, true);
   }
 
-  seedGenerator({ nativeEvent }) {
-    const distance =
-      Math.sqrt(((nativeEvent.pageX - this.state.lastCaptured.x) ** 2) +
-      ((nativeEvent.pageY - this.state.lastCaptured.y) ** 2));
+  seedGenerator(nativeEvent) {
+    let shouldTrigger;
+    if (typeof nativeEvent === 'string') {
+      shouldTrigger = true;
+    } else {
+      const distance =
+        Math.sqrt(((nativeEvent.pageX - this.state.lastCaptured.x) ** 2) +
+        ((nativeEvent.pageY - this.state.lastCaptured.y) ** 2));
+      shouldTrigger = distance > 120;
+    }
 
-    if (distance > 120 && (!this.state.data || this.state.data.percentage < 100)) {
+    if (shouldTrigger && (!this.state.data || this.state.data.percentage < 100)) {
       this.setState({
         lastCaptured: {
           x: nativeEvent.pageX,
@@ -70,7 +92,14 @@ class PassphraseGenerator extends React.Component {
     return (
       <div className={`${grid.row} ${grid['center-xs']}`} >
         <div className={grid['col-xs-12']}>
-          <p>Move your mouse to generate random bytes</p>
+          {isTouchDevice() ?
+            <div>
+              <p>Enter text below to generate random bytes</p>
+              <Input onChange={this.seedGeneratorBoundToThis}
+                autoFocus={true} multiline={true} />
+            </div> :
+            <p>Move your mouse to generate random bytes</p>
+          }
         </div>
         <div className={grid['col-xs-12']}>
           <ProgressBar mode='determinate'

--- a/src/components/passphrase/passphraseGenerator.test.js
+++ b/src/components/passphrase/passphraseGenerator.test.js
@@ -11,10 +11,8 @@ describe('PassphraseConfirmator', () => {
       changeHandler: () => {},
     };
     const mockEvent = {
-      nativeEvent: {
-        pageX: 140,
-        pageY: 140,
-      },
+      pageX: 140,
+      pageY: 140,
     };
 
     it('calls setState to setValues locally', () => {
@@ -38,13 +36,11 @@ describe('PassphraseConfirmator', () => {
 
     it('should do nothing if distance is bellow 120', () => {
       const wrapper = shallow(<PassphraseGenerator changeHandler={props.changeHandler}/>);
-      const shortDistanceEvent = {
-        nativeEvent: {
-          pageX: 10,
-          pageY: 10,
-        },
+      const nativeEvent = {
+        pageX: 10,
+        pageY: 10,
       };
-      wrapper.instance().seedGenerator(shortDistanceEvent);
+      wrapper.instance().seedGenerator(nativeEvent);
 
       expect(wrapper.instance().state.data).to.be.equal(undefined);
       expect(wrapper.instance().state.lastCaptured).to.deep.equal({

--- a/src/components/passphrase/passphraseGenerator.test.js
+++ b/src/components/passphrase/passphraseGenerator.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
-import { shallow } from 'enzyme';
+import { spy, mock } from 'sinon';
+import { mount, shallow } from 'enzyme';
 import PassphraseGenerator from './passphraseGenerator';
 
 
@@ -21,6 +21,31 @@ describe('PassphraseConfirmator', () => {
       wrapper.instance().seedGenerator(mockEvent);
       expect(spyFn).to.have.been.calledWith();
       wrapper.instance().setState.restore();
+    });
+
+    it('shows an Input fallback if this.isTouchDevice()', () => {
+      const wrapper = mount(<PassphraseGenerator changeHandler={props.changeHandler}/>);
+      const isTouchDeviceMock = mock(wrapper.instance()).expects('isTouchDevice');
+      isTouchDeviceMock.returns(true);
+      wrapper.instance().setState({}); // to rerender the component
+      expect(wrapper.find('.touch-fallback textarea')).to.have.lengthOf(1);
+    });
+
+    it('shows at least some progress on pressing input if this.isTouchDevice()', () => {
+      const wrapper = mount(<PassphraseGenerator changeHandler={props.changeHandler}/>);
+      const isTouchDeviceMock = mock(wrapper.instance()).expects('isTouchDevice');
+      isTouchDeviceMock.returns(true).twice();
+      wrapper.instance().setState({}); // to rerender the component
+      wrapper.find('.touch-fallback textarea').simulate('change', { target: { value: 'random key presses' } });
+      expect(wrapper.find('ProgressBar').props().value).to.be.at.least(1);
+    });
+
+    it('removes mousemove event listener in componentWillUnmount', () => {
+      const wrapper = mount(<PassphraseGenerator changeHandler={props.changeHandler}/>);
+      const documentSpy = spy(document, 'removeEventListener');
+      wrapper.instance().componentWillUnmount();
+      expect(documentSpy).to.have.be.been.calledWith('mousemove');
+      documentSpy.restore();
     });
 
     it('sets "data" and "lastCaptured" if distance is over 120', () => {

--- a/src/components/passphrase/passphraseVerifier.js
+++ b/src/components/passphrase/passphraseVerifier.js
@@ -40,7 +40,7 @@ class PassphraseConfirmator extends React.Component {
 
   render() {
     return (
-      <div className={`${grid.row} ${grid['start-xs']}`}>
+      <div className={`passphrase-verifier ${grid.row} ${grid['start-xs']}`}>
         <div className={grid['col-xs-12']}>
           <p>
             <span>{this.state.passphraseParts[0]}</span>

--- a/src/components/passphrase/passphraseVerifier.js
+++ b/src/components/passphrase/passphraseVerifier.js
@@ -20,7 +20,7 @@ class PassphraseConfirmator extends React.Component {
 
   hideRandomWord(rand = Math.random()) {
     const words = this.props.passphrase.trim().split(/\s+/);
-    const index = Math.floor(rand * words.length);
+    const index = Math.floor(rand * (words.length - 1));
 
     this.setState({
       passphraseParts: this.props.passphrase.split(` ${words[index]} `),

--- a/src/components/passphrase/passphraseVerifier.test.js
+++ b/src/components/passphrase/passphraseVerifier.test.js
@@ -38,7 +38,7 @@ describe('PassphraseVerifier', () => {
       const wrapper = shallow(<PassphraseVerifier passphrase={props.passphrase}
       updateAnswer={props.updateAnswer}/>);
 
-      const randomIndex = 0.5;
+      const randomIndex = 0.6;
       const expectedValues = {
         passphraseParts: [
           'survey stereo pool fortune oblige slight',


### PR DESCRIPTION
- [x] bind `mousemove` event in "generate" step to `body`, not just the component
- [x] have the "touchscreen fallback" for "generate" step. 
- [x] decrease left/right margin of the content to align with the buttons.
- [x] the step with "Yes it's safe" button should say "Save your passphrase in a safe place"
Closes #566