### PR TITLE
Omit data attribute on props in votingRow

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "flexboxgrid": "=6.3.1",
     "js-cookie": "^2.1.4",
     "lisk-js": "=0.4.5",
+    "lodash": "^4.17.4",
     "moment": "=2.15.1",
     "postcss": "=6.0.2",
     "postcss-cssnext": "=2.11.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "flexboxgrid": "=6.3.1",
     "js-cookie": "^2.1.4",
     "lisk-js": "=0.4.5",
-    "lodash": "^4.17.4",
     "moment": "=2.15.1",
     "postcss": "=6.0.2",
     "postcss-cssnext": "=2.11.0",

--- a/src/components/voting/votingRow.js
+++ b/src/components/voting/votingRow.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { TableRow, TableCell } from 'react-toolbox/lib/table';
-import omit from 'lodash/omit';
 import Checkbox from './voteCheckbox';
 import styles from './voting.css';
 
@@ -21,8 +20,8 @@ class VotingRow extends React.Component {
 
   render() {
     const props = this.props;
-    const { data } = props;
-    return (<TableRow {...omit(props, ['data'])} className={`${styles.row} ${setRowClass(data)}`}>
+    const { data, ...otherProps } = props;
+    return (<TableRow {...otherProps} className={`${styles.row} ${setRowClass(data)}`}>
       <TableCell>
         <Checkbox styles={styles}
           value={data.selected}

--- a/src/components/voting/votingRow.js
+++ b/src/components/voting/votingRow.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { TableRow, TableCell } from 'react-toolbox/lib/table';
-import styles from './voting.css';
+import omit from 'lodash/omit';
 import Checkbox from './voteCheckbox';
+import styles from './voting.css';
 
 const setRowClass = ({ pending, selected, voted }) => {
   if (pending) {
@@ -21,7 +22,7 @@ class VotingRow extends React.Component {
   render() {
     const props = this.props;
     const { data } = props;
-    return (<TableRow {...props} className={`${styles.row} ${setRowClass(data)}`}>
+    return (<TableRow {...omit(props, ['data'])} className={`${styles.row} ${setRowClass(data)}`}>
       <TableCell>
         <Checkbox styles={styles}
           value={data.selected}


### PR DESCRIPTION
Fix issue with data-* attribute on votingRow
I directly add `lodash` to package.json, maybe if you prefer, i can just add `lodash.omit`

Before
![image](https://user-images.githubusercontent.com/582703/29859647-6395c594-8d63-11e7-9ceb-d993ab1b5d83.png)

After
![image](https://user-images.githubusercontent.com/582703/29859655-6ae49fbe-8d63-11e7-94f1-4e5a37c8f2ec.png)
