### PR TITLE
Show a warning if passphrase contains extra whitespace

### DIFF
--- a/src/components/passphraseInput/index.js
+++ b/src/components/passphraseInput/index.js
@@ -19,11 +19,18 @@ class PassphraseInput extends React.Component {
 
   handleValueChange(value) {
     let error;
+    let warning;
+
     if (!value) {
       error = 'Required';
     } else if (!isValidPassphrase(value)) {
       error = this.getPassphraseValidationError(value);
+    } else if (this.hasExtraWhitespace(value)) {
+      const warningMessage = this.getPasshraseWhitespaceWarning(value);
+      warning = warningMessage ? `Warning: ${warningMessage}` : null;
     }
+
+    this.setState({ warning });
     this.props.onChange(value, error);
   }
 
@@ -47,6 +54,25 @@ class PassphraseInput extends React.Component {
     return 'Passphrase is not valid';
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  hasExtraWhitespace(passphrase) {
+    const normalizedValue = passphrase.replace(/ +/g, ' ').trim();
+    return normalizedValue !== passphrase;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getPasshraseWhitespaceWarning(passphrase) {
+    if (passphrase.replace(/^\s+/, '') !== passphrase) {
+      return 'Passphrase contains unnecessary whitespace at the beginning';
+    } else if (passphrase.replace(/\s+$/, '') !== passphrase) {
+      return 'Passphrase contains unnecessary whitespace at the end';
+    } else if (passphrase.replace(/\s+/g, ' ') !== passphrase) {
+      return 'Passphrase contains extra whitespace between words';
+    }
+
+    return null;
+  }
+
   toggleInputType() {
     this.setState({ inputType: this.state.inputType === 'password' ? 'text' : 'password' });
   }
@@ -56,7 +82,7 @@ class PassphraseInput extends React.Component {
       <div className={styles.wrapper}>
         <Input label={this.props.label} required={true}
           className={this.props.className}
-          error={this.props.error}
+          error={this.props.error || this.state.warning}
           value={this.props.value || ''}
           type={this.state.inputType}
           theme={this.props.theme}


### PR DESCRIPTION
Hi!

I've noticed that a lot of people are having trouble logging in to their existing address, because they enter the passphrase with extra whitespace somewhere, they get a different empty address and they freak out that their money is gone, e.g: https://www.reddit.com/r/Lisk/comments/73n57o/help_lisk_is_gone/. This is really something that the app should prevent from happening at all... so I decided to do something about it.

One tricky thing here is that some people might have already entered the whitespace wrong when creating a wallet, so if we add validation that prevents them from logging in with a bad passphrase, they won't be able to get back to their wallet at all... so instead I added a 'warning' to the passphrase input component that is displayed just like an error, but isn't passed outside as an error, so it doesn't disable the login button. You're still able to log in with such incorrect passphrase, if you really need to, but it will be obvious to you that something is wrong, if that's not your intention.

I'm not sure how well I managed to do this in terms of proper React architecture... I have basically zero experience with anything in JavaScript that came after the ES5/jQuery/Backbone era. But it seems to be working 🙂 I couldn't figure out how to write a test though, I couldn't find any way to access the component's state with a warning field through the wrapper.

So it probably needs some more work, but I hope you'll be able to do something with this and merge it.

![screen shot 2017-10-02 at 22 01 26](https://user-images.githubusercontent.com/28465/31096751-5bcf9622-a7bd-11e7-8d78-01e9004f0c14.png)
![screen shot 2017-10-02 at 22 01 33](https://user-images.githubusercontent.com/28465/31096754-5c02afa8-a7bd-11e7-9aa1-97364090f7b8.png)
![screen shot 2017-10-02 at 22 01 42](https://user-images.githubusercontent.com/28465/31096753-5bfea7be-a7bd-11e7-8432-d68e8f6d81fa.png)
