### PR TITLE
Remove extra request for online/offline status - Closes #822

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,4 +1,4 @@
-import { getAccountStatus, getAccount, transactions } from '../../utils/api/account';
+import { getAccount, transactions } from '../../utils/api/account';
 import { accountUpdated, accountLoggedIn } from '../../actions/account';
 import { transactionsUpdated } from '../../actions/transactions';
 import { activePeerUpdate } from '../../actions/peers';
@@ -45,9 +45,6 @@ const updateAccountData = (store, action) => { // eslint-disable-line
       }
     }
     store.dispatch(accountUpdated(result));
-  });
-
-  return getAccountStatus(peers.data).then(() => {
     store.dispatch(activePeerUpdate({ online: true }));
   }).catch((res) => {
     store.dispatch(activePeerUpdate({ online: false, code: res.error.code }));

--- a/src/utils/api/account.js
+++ b/src/utils/api/account.js
@@ -35,9 +35,6 @@ export const transactions = (activePeer, address, limit = 20, offset = 0, orderB
     orderBy,
   });
 
-export const getAccountStatus = activePeer =>
-  requestToActivePeer(activePeer, 'loader/status', {});
-
 export const extractPublicKey = passphrase =>
   Lisk.crypto.getKeys(passphrase).publicKey;
 


### PR DESCRIPTION
What's the Problem?
We make an unnecessary request every 10 second just to check if the client is online or not.
[#822](https://github.com/LiskHQ/lisk-nano/issues/822)

What did you do to solve it?
- got rid of "getAccountStatus"
- also updates the tests accordingly 

How can I test this?
- run the tests
- check locally if the online/offline notifications are behaving like before
