### PR TITLE
Downgrade Storybook to 3.2.12 - Closes #837

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "3.3.0-alpha.1",
+    "@storybook/addon-actions": "3.2.12",
     "@storybook/react": "3.2.10",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",


### PR DESCRIPTION
Because the newer alpha version got lost from npm. So much for using greenkeeper to get the latest dependencies.
Closes #837