### PR TITLE
Remove submitting on enter in vote form - Closes #840

### DIFF
--- a/src/components/voteDialog/voteDialog.js
+++ b/src/components/voteDialog/voteDialog.js
@@ -50,7 +50,7 @@ export default class VoteDialog extends React.Component {
     });
     return (
       <article>
-        <form onSubmit={this.confirm.bind(this)}>
+        <form>
           <Autocomplete
             votedDelegates={this.props.delegates}
             votes={this.props.votes}
@@ -77,8 +77,9 @@ export default class VoteDialog extends React.Component {
             }}
             primaryButton={{
               label: this.props.t('Confirm'),
+              onClick: this.confirm.bind(this),
               fee: Fees.vote,
-              type: 'submit',
+              type: 'button',
               disabled: (
                 totalVotes > maxCountOfVotes ||
                 votesList.length === 0 ||

--- a/src/components/voteDialog/voteDialog.js
+++ b/src/components/voteDialog/voteDialog.js
@@ -50,7 +50,7 @@ export default class VoteDialog extends React.Component {
     });
     return (
       <article>
-        <form>
+        <form id='voteform'>
           <Autocomplete
             votedDelegates={this.props.delegates}
             votes={this.props.votes}

--- a/src/components/voteDialog/voteDialog.test.js
+++ b/src/components/voteDialog/voteDialog.test.js
@@ -75,8 +75,14 @@ describe('VoteDialog', () => {
       expect(wrapper.find('ActionBar')).to.have.lengthOf(1);
     });
 
-    it('should fire votePlaced action if lists are not empty and account balance is sufficient', () => {
+    it('should not submit form on enter press', () => {
       wrapper.find('VoteDialog .primary-button button').simulate('submit');
+
+      expect(props.votePlaced).not.to.have.been.calledWith();
+    });
+
+    it('should fire votePlaced action if lists are not empty and account balance is sufficient', () => {
+      wrapper.find('VoteDialog .primary-button button').simulate('click');
 
       expect(props.votePlaced).to.have.been.calledWith({
         account: ordinaryAccount,
@@ -109,7 +115,7 @@ describe('VoteDialog', () => {
       wrapper = mount(<VoteDialog {...props} account={accountWithSecondPassphrase} />, options);
       const secondPassphrase = 'test second passphrase';
       wrapper.instance().handleChange('secondPassphrase', secondPassphrase);
-      wrapper.find('.primary-button button').simulate('submit');
+      wrapper.find('.primary-button button').simulate('click');
 
       expect(props.votePlaced).to.have.been.calledWith({
         activePeer: props.activePeer,

--- a/src/components/voteDialog/voteDialog.test.js
+++ b/src/components/voteDialog/voteDialog.test.js
@@ -76,7 +76,7 @@ describe('VoteDialog', () => {
     });
 
     it('should not submit form on enter press', () => {
-      wrapper.find('VoteDialog .primary-button button').simulate('submit');
+      wrapper.find('#voteform').simulate('submit');
 
       expect(props.votePlaced).not.to.have.been.calledWith();
     });


### PR DESCRIPTION
What's the Problem?
Vote form submits on enter: [#840](https://github.com/LiskHQ/lisk-nano/issues/840)

What did you do?
Simply changed button type to button

How can I test this?
- Run test
- Go to "vote"
- Search for a delegate in "Add vote to" or "Remove vote from" and select a delegate
press enter -> the selected delegate is added and the form is NOT submitted anymore. 
- Now click the "confirm" button -> form should be submitted now