### PR TITLE
Add e2e tests for infinite scroll - Closes #740

### DIFF
--- a/features/forging.feature
+++ b/features/forging.feature
@@ -3,3 +3,10 @@ Feature: Forging tab
     Given I'm logged in as "delegate"
     When I click tab number 3
     Then I should see forging center
+
+  Scenario: should show more blocks on scroll
+    Given I'm logged in as "delegate"
+    When I click tab number 3
+    Then I should see table with 20 lines
+    When I scroll to the bottom
+    Then I should see table with 40 lines

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -174,5 +174,9 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
   When('I Refresh the page', (callback) => {
     browser.refresh().then(callback);
   });
+
+  When('I scroll to the bottom', () => {
+    browser.executeScript('window.scrollBy(0, 10000);');
+  });
 });
 

--- a/features/transactions.feature
+++ b/features/transactions.feature
@@ -4,6 +4,13 @@ Feature: Transactions tab
     When I click tab number 1
     Then I should see table with 40 lines
 
+  Scenario: should show more transactions on scroll
+    Given I'm logged in as "genesis"
+    When I click tab number 1
+    Then I should see table with 40 lines
+    When I scroll to the bottom
+    Then I should see table with 60 lines
+
   Scenario: should allow send to address
     Given I'm logged in as "genesis"
     When I click tab number 1

--- a/features/voting.feature
+++ b/features/voting.feature
@@ -4,6 +4,13 @@ Feature: Voting tab
     When I click tab number 2
     Then I should see table with 100 lines
 
+  Scenario: should allow to view more delegates on scroll
+    Given I'm logged in as "any account"
+    When I click tab number 2
+    Then I should see table with 100 lines
+    When I scroll to the bottom
+    Then I should see table with 200 lines
+
   Scenario: should allow to view delegates with cold account
     Given I'm logged in as "empty account"
     When I click tab number 2

--- a/src/components/transactions/transactions.js
+++ b/src/components/transactions/transactions.js
@@ -53,7 +53,7 @@ class Transactions extends React.Component {
               to='receive'>{this.props.t('Receive LSK')}</RelativeLink>
           </p>
         }
-        <Waypoint bottomOffset='-100%'
+        <Waypoint bottomOffset='-80%'
           scrollableAncestor={window}
           key={this.props.transactions.length}
           onEnter={this.loadMore.bind(this)}></Waypoint>

--- a/src/components/transactions/transactions.js
+++ b/src/components/transactions/transactions.js
@@ -53,7 +53,7 @@ class Transactions extends React.Component {
               to='receive'>{this.props.t('Receive LSK')}</RelativeLink>
           </p>
         }
-        <Waypoint bottomOffset='-80%'
+        <Waypoint bottomOffset='-100%'
           scrollableAncestor={window}
           key={this.props.transactions.length}
           onEnter={this.loadMore.bind(this)}></Waypoint>


### PR DESCRIPTION
What's the Problem?
There were no tests for the infinite scroll [#740](https://github.com/LiskHQ/lisk-nano/issues/740)

What did you do?
- Added tests for transactions, voting and forging
- Changed the bottomOffset to load more transactions -> fixes a failing test

How can I test this?
- Run the e2e tests
- Check scrolling still behaves normal in the browser