### PR TITLE
Get Blockchain Nethash from API - Closes #830

### DIFF
--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -1,6 +1,6 @@
 import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
-import { getNethash } from './../utils/api/peers';
+import { getNethash } from './../utils/api/nethash';
 
 const peerSet = (data, config) => ({
   data: Object.assign({

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -1,5 +1,6 @@
 import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
+import { getNetHash } from './../utils/api/peers';
 
 /**
  * Returns required action object to set
@@ -9,37 +10,42 @@ import actionTypes from '../constants/actions';
  * @param {Object} data - Active peer data and the passphrase of account
  * @returns {Object} Action object
  */
-export const activePeerSet = (data) => {
-  const addHttp = (url) => {
-    const reg = /^(?:f|ht)tps?:\/\//i;
-    return reg.test(url) ? url : `http://${url}`;
-  };
+export const activePeerSet = data =>
+  (dispatch) => {
+    const addHttp = (url) => {
+      const reg = /^(?:f|ht)tps?:\/\//i;
+      return reg.test(url) ? url : `http://${url}`;
+    };
 
-  const { network } = data;
-  let config = { };
-  if (network) {
-    config = network;
-    if (network.address) {
-      const normalizedUrl = new URL(addHttp(network.address));
+    const { network } = data;
+    let config = {};
+    if (network) {
+      config = network;
+      if (network.address) {
+        const normalizedUrl = new URL(addHttp(network.address));
 
-      config.node = normalizedUrl.hostname;
-      config.port = normalizedUrl.port;
-      config.ssl = normalizedUrl.protocol === 'https';
+        config.node = normalizedUrl.hostname;
+        config.port = normalizedUrl.port;
+        config.ssl = normalizedUrl.protocol === 'https';
+      }
+      if (config.testnet === undefined && config.port !== undefined) {
+        config.testnet = config.port === '7000';
+      }
+      if (network.custom) {
+        getNetHash(Lisk.api(config)).then((response) => {
+          config.nethash = response.nethash;
+        });
+      }
     }
-    if (config.testnet === undefined && config.port !== undefined) {
-      config.testnet = config.port === '7000';
-    }
-  }
-
-  return {
-    data: Object.assign({
-      passphrase: data.passphrase,
-      publicKey: data.publicKey,
-      activePeer: Lisk.api(config),
-    }),
-    type: actionTypes.activePeerSet,
+    dispatch({
+      data: Object.assign({
+        passphrase: data.passphrase,
+        publicKey: data.publicKey,
+        activePeer: Lisk.api(config),
+      }),
+      type: actionTypes.activePeerSet,
+    });
   };
-};
 
 /**
  * Returns required action object to partially

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -2,6 +2,15 @@ import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
 import { getNetHash } from './../utils/api/peers';
 
+const peerSet = (data, config) => ({
+  data: Object.assign({
+    passphrase: data.passphrase,
+    publicKey: data.publicKey,
+    activePeer: Lisk.api(config),
+  }),
+  type: actionTypes.activePeerSet,
+});
+
 /**
  * Returns required action object to set
  * the given peer data as active peer
@@ -34,18 +43,16 @@ export const activePeerSet = data =>
       if (network.custom) {
         getNetHash(Lisk.api(config)).then((response) => {
           config.nethash = response.nethash;
+          dispatch(peerSet(data, config));
         });
+      } else {
+        dispatch(peerSet(data, config));
       }
+    } else {
+      dispatch(peerSet(data, config));
     }
-    dispatch({
-      data: Object.assign({
-        passphrase: data.passphrase,
-        publicKey: data.publicKey,
-        activePeer: Lisk.api(config),
-      }),
-      type: actionTypes.activePeerSet,
-    });
   };
+
 
 /**
  * Returns required action object to partially

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -25,29 +25,23 @@ export const activePeerSet = data =>
       const reg = /^(?:f|ht)tps?:\/\//i;
       return reg.test(url) ? url : `http://${url}`;
     };
+    const config = data.network || {};
 
-    const { network } = data;
-    let config = {};
-    if (network) {
-      config = network;
-      if (network.address) {
-        const normalizedUrl = new URL(addHttp(network.address));
+    if (config.address) {
+      const { hostname, port, protocol } = new URL(addHttp(config.address));
 
-        config.node = normalizedUrl.hostname;
-        config.port = normalizedUrl.port;
-        config.ssl = normalizedUrl.protocol === 'https';
-      }
-      if (config.testnet === undefined && config.port !== undefined) {
-        config.testnet = config.port === '7000';
-      }
-      if (network.custom) {
-        getNetHash(Lisk.api(config)).then((response) => {
-          config.nethash = response.nethash;
-          dispatch(peerSet(data, config));
-        });
-      } else {
+      config.node = hostname;
+      config.port = port;
+      config.ssl = protocol === 'https';
+    }
+    if (config.testnet === undefined && config.port !== undefined) {
+      config.testnet = config.port === '7000';
+    }
+    if (config.custom) {
+      getNetHash(Lisk.api(config)).then((response) => {
+        config.nethash = response.nethash;
         dispatch(peerSet(data, config));
-      }
+      });
     } else {
       dispatch(peerSet(data, config));
     }

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -1,6 +1,6 @@
 import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
-import { getNetHash } from './../utils/api/peers';
+import { getNethash } from './../utils/api/peers';
 
 const peerSet = (data, config) => ({
   data: Object.assign({
@@ -38,7 +38,7 @@ export const activePeerSet = data =>
       config.testnet = config.port === '7000';
     }
     if (config.custom) {
-      getNetHash(Lisk.api(config)).then((response) => {
+      getNethash(Lisk.api(config)).then((response) => {
         config.nethash = response.nethash;
         dispatch(peerSet(data, config));
       });

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -37,7 +37,7 @@ describe('actions: peers', () => {
     });
 
     it('creates active peer config', () => {
-      getNetHash.returnsPromise().resolves({ nethash });
+      getNetHash.returnsPromise();
       const data = {
         passphrase,
         network: {
@@ -50,6 +50,7 @@ describe('actions: peers', () => {
       };
 
       activePeerSet(data)(dispatch);
+      getNetHash.resolves({ nethash });
 
       expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options', data.network));
     });
@@ -63,13 +64,14 @@ describe('actions: peers', () => {
     });
 
     it('dispatch activePeerSet with nethash from response when the network is a custom node', () => {
-      getNetHash.returnsPromise().resolves({ nethash: 'nethash from response' });
+      getNetHash.returnsPromise();
       const network = {
         address: 'http://localhost:4000',
         custom: true,
       };
 
       activePeerSet({ passphrase, network })(dispatch);
+      getNetHash.resolves({ nethash: 'nethash from response' });
 
       expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.nethash.nethash', 'nethash from response'));
     });

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
 import actionTypes from '../constants/actions';
 import { activePeerSet, activePeerUpdate } from './peers';
-import * as peersApi from './../utils/api/peers';
+import * as nethashApi from './../utils/api/nethash';
 
 
 describe('actions: peers', () => {
@@ -29,7 +29,7 @@ describe('actions: peers', () => {
 
     beforeEach(() => {
       dispatch = spy();
-      getNetHash = stub(peersApi, 'getNethash');
+      getNetHash = stub(nethashApi, 'getNethash');
     });
 
     afterEach(() => {

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -29,7 +29,7 @@ describe('actions: peers', () => {
 
     beforeEach(() => {
       dispatch = spy();
-      getNetHash = stub(peersApi, 'getNetHash');
+      getNetHash = stub(peersApi, 'getNethash');
     });
 
     afterEach(() => {

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
-import Lisk from 'lisk-js';
+import { spy, stub, match } from 'sinon';
 import actionTypes from '../constants/actions';
 import { activePeerSet, activePeerUpdate } from './peers';
+import * as peersApi from './../utils/api/peers';
 
 
 describe('actions: peers', () => {
   const passphrase = 'wagon stock borrow episode laundry kitten salute link globe zero feed marble';
+  const nethash = '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d';
 
   describe('activePeerUpdate', () => {
     it('should create an action to update the active peer', () => {
@@ -23,7 +24,20 @@ describe('actions: peers', () => {
   });
 
   describe('activePeerSet', () => {
+    let dispatch;
+    let getNetHash;
+
+    beforeEach(() => {
+      dispatch = spy();
+      getNetHash = stub(peersApi, 'getNetHash');
+    });
+
+    afterEach(() => {
+      getNetHash.restore();
+    });
+
     it('creates active peer config', () => {
+      getNetHash.returnsPromise().resolves({ nethash });
       const data = {
         passphrase,
         network: {
@@ -31,57 +45,56 @@ describe('actions: peers', () => {
           custom: true,
           address: 'http://localhost:4000',
           testnet: true,
-          nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
+          nethash,
         },
       };
-      const actionSpy = spy(Lisk, 'api');
-      activePeerSet(data);
-      expect(actionSpy).to.have.been.calledWith(data.network);
-      Lisk.api.restore();
+
+      activePeerSet(data)(dispatch);
+
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options', data.network));
     });
 
     it('dispatch activePeerSet action also when address http missing', () => {
-      const data = {
-        passphrase,
-        network: {
-          address: 'localhost:8000',
-        },
+      const network = { address: 'localhost:8000' };
+
+      activePeerSet({ passphrase, network })(dispatch);
+
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.address', 'localhost:8000'));
+    });
+
+    it('dispatch activePeerSet with nethash from response when the network is a custom node', () => {
+      getNetHash.returnsPromise().resolves({ nethash: 'nethash from response' });
+      const network = {
+        address: 'http://localhost:4000',
+        custom: true,
       };
-      const actionSpy = spy(Lisk, 'api');
-      activePeerSet(data);
-      expect(actionSpy).to.have.been.calledWith();
-      Lisk.api.restore();
+
+      activePeerSet({ passphrase, network })(dispatch);
+
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.nethash', 'nethash from response'));
     });
 
     it('dispatch activePeerSet action even if network is undefined', () => {
-      const data = { passphrase };
-      const actionSpy = spy(Lisk, 'api');
-      activePeerSet(data);
-      expect(actionSpy).to.have.been.calledWith();
-      Lisk.api.restore();
+      activePeerSet({ passphrase })(dispatch);
+
+      expect(dispatch).to.have.been.calledWith();
     });
 
     it('dispatch activePeerSet action even if network.address is undefined', () => {
-      const data = { passphrase, network: {} };
-      const actionSpy = spy(Lisk, 'api');
-      activePeerSet(data);
-      expect(actionSpy).to.have.been.calledWith();
-      Lisk.api.restore();
+      activePeerSet({ passphrase, network: {} })(dispatch);
+
+      expect(dispatch).to.have.been.calledWith();
     });
 
     it('should set to testnet if not defined in config but port is 7000', () => {
-      const network7000 = {
-        address: 'http://127.0.0.1:7000',
-        nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-      };
-      const network4000 = {
-        address: 'http://127.0.0.1:4000',
-        nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-      };
-      let actionObj = activePeerSet({ passphrase, network: network7000 });
-      expect(actionObj.data.activePeer.testnet).to.be.equal(true);
-      actionObj = activePeerSet({ passphrase, network: network4000 });
-      expect(actionObj.data.activePeer.testnet).to.be.equal(false);
+      const network7000 = { address: 'http://127.0.0.1:7000', nethash };
+      const network4000 = { address: 'http://127.0.0.1:4000', nethash };
+
+      activePeerSet({ passphrase, network: network7000 })(dispatch);
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.testnet', true));
+
+      activePeerSet({ passphrase, network: network4000 })(dispatch);
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.testnet', false));
     });
   });
 });

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -71,7 +71,7 @@ describe('actions: peers', () => {
 
       activePeerSet({ passphrase, network })(dispatch);
 
-      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.nethash', 'nethash from response'));
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.nethash.nethash', 'nethash from response'));
     });
 
     it('dispatch activePeerSet action even if network is undefined', () => {

--- a/src/components/login/networks.js
+++ b/src/components/login/networks.js
@@ -1,5 +1,4 @@
 import i18next from 'i18next';
-import env from '../../constants/env';
 
 export default () => ([
   {
@@ -15,9 +14,5 @@ export default () => ([
     name: i18next.t('Custom Node'),
     custom: true,
     address: 'http://localhost:4000',
-    ...(env.production ? {} : {
-      testnet: true,
-      nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-    }),
   },
 ]);

--- a/src/utils/api/nethash.js
+++ b/src/utils/api/nethash.js
@@ -1,0 +1,4 @@
+import { requestToActivePeer } from './peers';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getNethash = activePeer => (requestToActivePeer(activePeer, 'blocks/getNethash'));

--- a/src/utils/api/nethash.test.js
+++ b/src/utils/api/nethash.test.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { mock } from 'sinon';
+import * as peers from './peers';
+import { getNethash } from './nethash';
+
+
+describe('Utils: Nethash', () => {
+  let peersMock;
+  const activePeer = {};
+
+  beforeEach(() => {
+    peersMock = mock(peers);
+  });
+
+  afterEach(() => {
+    peersMock.restore();
+  });
+
+  it('should return the result from requestToActivePeer call', () => {
+    const mockedReturns = 'requestToActivePeer returns something';
+
+    peersMock.expects('requestToActivePeer')
+      .withArgs(activePeer, 'blocks/getNethash')
+      .returns(mockedReturns);
+
+    const returnedPromise = getNethash(activePeer);
+    expect(returnedPromise).to.equal(mockedReturns);
+  });
+});

--- a/src/utils/api/peers.js
+++ b/src/utils/api/peers.js
@@ -1,7 +1,6 @@
 import { loadingStarted, loadingFinished } from '../../utils/loading';
 
-/* eslint-disable  */
-export const requestToActivePeer = (activePeer, path, urlParams) =>
+const requestToActivePeer = (activePeer, path, urlParams) =>
   new Promise((resolve, reject) => {
     loadingStarted(path);
     activePeer.sendRequest(path, urlParams, (data) => {
@@ -13,4 +12,8 @@ export const requestToActivePeer = (activePeer, path, urlParams) =>
       loadingFinished(path);
     });
   });
-/* eslint-enable */
+
+
+const getNetHash = activePeer => (requestToActivePeer(activePeer, 'blocks/getNethash'));
+
+export { requestToActivePeer, getNetHash };

--- a/src/utils/api/peers.js
+++ b/src/utils/api/peers.js
@@ -1,6 +1,7 @@
 import { loadingStarted, loadingFinished } from '../../utils/loading';
 
-const requestToActivePeer = (activePeer, path, urlParams) =>
+// eslint-disable-next-line import/prefer-default-export
+export const requestToActivePeer = (activePeer, path, urlParams) =>
   new Promise((resolve, reject) => {
     loadingStarted(path);
     activePeer.sendRequest(path, urlParams, (data) => {
@@ -12,8 +13,3 @@ const requestToActivePeer = (activePeer, path, urlParams) =>
       loadingFinished(path);
     });
   });
-
-
-const getNethash = activePeer => (requestToActivePeer(activePeer, 'blocks/getNethash'));
-
-export { requestToActivePeer, getNethash };

--- a/src/utils/api/peers.js
+++ b/src/utils/api/peers.js
@@ -14,6 +14,6 @@ const requestToActivePeer = (activePeer, path, urlParams) =>
   });
 
 
-const getNetHash = activePeer => (requestToActivePeer(activePeer, 'blocks/getNethash'));
+const getNethash = activePeer => (requestToActivePeer(activePeer, 'blocks/getNethash'));
 
-export { requestToActivePeer, getNetHash };
+export { requestToActivePeer, getNethash };


### PR DESCRIPTION
What's the Problem?
The nethash was hardcoded for the localhost development [830](https://github.com/LiskHQ/lisk-nano/issues/830)

What did you do?
- Added a request to get the nethash from 'api/blocks/getNethash' instead
- Updated tests

How can I test this?
- Run the tests
- Try to make transactions