### PR TITLE
Add missing error toast for unavailable custom node - Closes #879

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -9,7 +9,8 @@ Feature: Login page
     Given I'm on login page
     When I fill in "wagon stock borrow episode laundry kitten salute link globe zero feed marble" to "passphrase" field
     And I select option no. 3 from "network" select
-    When I fill in an incorrect address
+    When I clear "address" field
+    And I fill in "http://localhost:4218" to "address" field
     And I click "login button"
     And I wait 1 seconds
     Then I should see text "Unable to connect to the node" in "toast" element

--- a/features/login.feature
+++ b/features/login.feature
@@ -5,6 +5,15 @@ Feature: Login page
     And I click "login button"
     Then I should be logged in
 
+  Scenario: should show toast when trying to connect to an unavailable custom node
+    Given I'm on login page
+    When I fill in "wagon stock borrow episode laundry kitten salute link globe zero feed marble" to "passphrase" field
+    And I select option no. 3 from "network" select
+    And I fill in "localhost:4218" to "address" field
+    And I click "login button"
+    And I wait 1 seconds
+    Then I should see text "Unable to connect to the node" in "toast" element
+
   Scenario: should allow to login to Mainnet 
     Given I'm on login page
     When I fill in "wagon stock borrow episode laundry kitten salute link globe zero feed marble" to "passphrase" field

--- a/features/login.feature
+++ b/features/login.feature
@@ -9,7 +9,7 @@ Feature: Login page
     Given I'm on login page
     When I fill in "wagon stock borrow episode laundry kitten salute link globe zero feed marble" to "passphrase" field
     And I select option no. 3 from "network" select
-    When I clear "address" field
+    And I clear "address" field
     And I fill in "http://localhost:4218" to "address" field
     And I click "login button"
     And I wait 1 seconds

--- a/features/login.feature
+++ b/features/login.feature
@@ -9,7 +9,7 @@ Feature: Login page
     Given I'm on login page
     When I fill in "wagon stock borrow episode laundry kitten salute link globe zero feed marble" to "passphrase" field
     And I select option no. 3 from "network" select
-    And I fill in "localhost:4218" to "address" field
+    When I fill in an incorrect address
     And I click "login button"
     And I wait 1 seconds
     Then I should see text "Unable to connect to the node" in "toast" element

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -129,6 +129,11 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
     waitForElemAndCheckItsText(selectorClass, text, callback);
   });
 
+  When('I fill in an incorrect address', () => {
+    browser.executeScript('window.document.querySelector(".address input").value = "";');
+    waitForElemAndSendKeys('.address input, .address textarea', 'http://localhost:4039');
+  });
+
   Given('I\'m logged in as "{accountName}"', (accountName, callback) => {
     browser.ignoreSynchronization = true;
     browser.driver.manage().window().setSize(1000, 1000);

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -129,9 +129,9 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
     waitForElemAndCheckItsText(selectorClass, text, callback);
   });
 
-  When('I fill in an incorrect address', () => {
-    browser.executeScript('window.document.querySelector(".address input").value = "";');
-    waitForElemAndSendKeys('.address input, .address textarea', 'http://localhost:4039');
+  When('I clear "{elementName}" field', (elementName) => {
+    const selectorClass = `.${elementName.replace(/ /g, '-')}`;
+    browser.executeScript(`window.document.querySelector("${selectorClass} input, ${selectorClass} textarea").value = "";`);
   });
 
   Given('I\'m logged in as "{accountName}"', (accountName, callback) => {

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -1,6 +1,8 @@
+import i18next from 'i18next';
 import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
 import { getNethash } from './../utils/api/nethash';
+import { errorToastDisplayed } from './toaster';
 
 const peerSet = (data, config) => ({
   data: Object.assign({
@@ -41,6 +43,8 @@ export const activePeerSet = data =>
       getNethash(Lisk.api(config)).then((response) => {
         config.nethash = response.nethash;
         dispatch(peerSet(data, config));
+      }).catch(() => {
+        dispatch(errorToastDisplayed({ label: i18next.t('Unable to connect to the node') }));
       });
     } else {
       dispatch(peerSet(data, config));


### PR DESCRIPTION
What's the problem?
There was no error toast when trying to connect to an unavailable custom node 
https://github.com/LiskHQ/lisk-nano/issues/879

What did you do?
- I added a missing catch to then display the toast
- Added e2e test

<img width="1018" alt="screen shot 2017-10-17 at 11 45 25" src="https://user-images.githubusercontent.com/9592216/31658207-b802675c-b330-11e7-8122-7adcecf07eca.png">
