### PR TITLE
Replace dot separators and remove unnecessary code - Closes #884

### DIFF
--- a/app/src/i18n.js
+++ b/app/src/i18n.js
@@ -17,10 +17,8 @@ i18n
     defaultNS: 'common',
     saveMissing: true,
     debug: false,
-  }, (err, t) => {
-    t('key');
-    // initialized and ready to go!
-    console.log(`Current language used: ${i18n.language}`); //eslint-disable-line
+    keySeparator: '>',
+    nsSeparator: '|',
   });
 
 export default i18n;


### PR DESCRIPTION
What's the problem?
Currently some strings couldn't be translated due to dot separation
https://github.com/LiskHQ/lisk-nano/issues/884

What did you do?
Added other separators in i18n, that replace the dot separator

How do I test this?
- Change your language to German in the electron app
- Then go to "Hilfe" in the title bar
- It should say "Fehler melden..." and "Neues..." instead of "Report issue..." and "What's new..."
