### PR TITLE
Fix about dialog on Windows - Closes #887

### DIFF
--- a/app/src/menu.js
+++ b/app/src/menu.js
@@ -128,8 +128,8 @@ module.exports = (app, copyright, i18n) => {
         if (focusedWindow) {
           const options = {
             buttons: ['OK'],
-            icon: `${__dirname}/assets/lisk.png`,
-            message: `${i18n.t('Lisk Nano')} \n ${i18n.t('Version')} ${app.getVersion()}\n${copyright}`,
+            icon: `${__dirname}/assets/images/lisk.png`,
+            message: `${i18n.t('Lisk Nano')}\n${i18n.t('Version')} ${app.getVersion()}\n${copyright}`,
           };
           electron.dialog.showMessageBox(focusedWindow, options, () => {});
         }


### PR DESCRIPTION
It had a wrong path to Lisk logo image and version was indented by one space.
Closes #887