### PR TITLE
Enable locale default select in browser and on reload - Closes #897

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -37,11 +37,15 @@ const sendDetectedLang = (locale) => {
 };
 
 // read config data from JSON file
-storage.get('config', (error, data) => {
-  if (error) throw error;
-  lang = data.lang;
-  sendDetectedLang(lang);
-});
+const getConfig = () => {
+  storage.get('config', (error, data) => {
+    if (error) throw error;
+    lang = data.lang;
+    sendDetectedLang(lang);
+  });
+};
+
+getConfig();
 
 function createWindow() {
   // set language of the react app
@@ -181,4 +185,8 @@ ipcMain.on('set-locale', (event, locale) => {
     Menu.setApplicationMenu(buildMenu(app, copyright, i18n));
     event.returnValue = 'Rebuilt electron menu.';
   }
+});
+
+ipcMain.on('request-locale', () => {
+  getConfig();
 });

--- a/src/utils/ipcLocale.js
+++ b/src/utils/ipcLocale.js
@@ -4,6 +4,10 @@ export default {
     let localeInit = false;
 
     if (ipc) {
+      if (!i18n.language) {
+        ipc.send('request-locale');
+      }
+
       ipc.on('detectedLocale', (action, locale) => {
         i18n.changeLanguage(locale);
         localeInit = true;
@@ -16,8 +20,11 @@ export default {
       });
     } else {
       const language = i18n.language || window.localStorage.getItem('lang');
-      if (language) i18n.changeLanguage(language);
-      else i18n.changeLanguage('en');
+      if (language) {
+        i18n.changeLanguage(language);
+      } else {
+        i18n.changeLanguage('en');
+      }
 
       i18n.on('languageChanged', (locale) => {
         window.localStorage.setItem('lang', locale);

--- a/src/utils/ipcLocale.js
+++ b/src/utils/ipcLocale.js
@@ -14,6 +14,14 @@ export default {
           ipc.send('set-locale', locale);
         }
       });
+    } else {
+      const language = i18n.language || window.localStorage.getItem('lang');
+      if (language) i18n.changeLanguage(language);
+      else i18n.changeLanguage('en');
+
+      i18n.on('languageChanged', (locale) => {
+        window.localStorage.setItem('lang', locale);
+      });
     }
   },
 };

--- a/src/utils/ipcLocale.test.js
+++ b/src/utils/ipcLocale.test.js
@@ -16,11 +16,38 @@ describe('ipcLocale', () => {
   describe('init', () => {
     beforeEach(() => {
       delete window.ipc;
+      i18n.language = '';
     });
-    it('calling init when ipc is not on window should do nothing', () => {
-      ipcLocale.init();
+
+    it('calling init when ipc is not on window does not call ipc', () => {
+      ipcLocale.init(i18n);
       expect(ipc.on).to.not.have.been.calledWith();
       expect(ipc.send).to.not.have.been.calledWith();
+    });
+
+    it('calling init when ipc is not on window saves locale in browser when there is no locale in i18n', () => {
+      window.localStorage.getItem = () => 'en';
+
+      ipcLocale.init(i18n);
+      expect(ipc.on).to.not.have.been.calledWith();
+      expect(ipc.send).to.not.have.been.calledWith();
+
+      expect(i18n.changeLanguage).to.have.been.calledWith('en');
+    });
+
+    it('calling init when ipc is not on window saves locale in browser when there is no locale in localStorage', () => {
+      window.localStorage.getItem = () => '';
+      i18n.language = 'de';
+
+      ipcLocale.init(i18n);
+      expect(i18n.changeLanguage).to.have.been.calledWith('de');
+    });
+
+    it('calling init when ipc is not on window saves locale in browser when there is no locale saved at all', () => {
+      window.localStorage.getItem = () => '';
+
+      ipcLocale.init(i18n);
+      expect(i18n.changeLanguage).to.have.been.calledWith('en');
     });
 
     it('should be a function', () => {
@@ -32,6 +59,13 @@ describe('ipcLocale', () => {
       ipcLocale.init(i18n);
       expect(ipc.on).to.have.been.calledWith();
       expect(i18n.on).to.have.been.calledWith();
+    });
+
+    it('calling init when ipc is available and there is no locale in i18n will make a request for locale ', () => {
+      window.ipc = ipc;
+
+      ipcLocale.init(i18n);
+      expect(ipc.send).to.have.been.calledWith('request-locale');
     });
   });
 });


### PR DESCRIPTION
What's the problem?
- In the browser there is no default locale selected
- In the electron app the default locale setting is gone on refresh
Closes https://github.com/LiskHQ/lisk-nano/issues/897

What did you do?
- Saved locale in localStorage in browser
- Added an event to make a new request for the locale in electron