### PR TITLE
Fix incorrectly triggered error toast in voting - Closes #911

### DIFF
--- a/src/components/voting/votingBar.js
+++ b/src/components/voting/votingBar.js
@@ -4,15 +4,13 @@ import grid from 'flexboxgrid/dist/flexboxgrid.css';
 
 import style from './votingBar.css';
 import votingConst from '../../constants/voting';
+import { getTotalVotesCount, getVoteList, getUnvoteList } from './../../utils/voting';
 
 const VotingBar = ({ votes, t }) => {
   const { maxCountOfVotes, maxCountOfVotesInOneTurn } = votingConst;
-  const votedList = Object.keys(votes).filter(key => votes[key].confirmed);
-  const voteList = Object.keys(votes).filter(
-    key => votes[key].unconfirmed && !votes[key].confirmed);
-  const unvoteList = Object.keys(votes).filter(
-    key => !votes[key].unconfirmed && votes[key].confirmed);
-  const totalVotesCount = (votedList.length - unvoteList.length) + voteList.length;
+  const voteList = getVoteList(votes);
+  const unvoteList = getUnvoteList(votes);
+  const totalVotesCount = getTotalVotesCount(votes);
   const totalNewVotesCount = voteList.length + unvoteList.length;
 
   return (voteList.length + unvoteList.length ?

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -5,6 +5,7 @@ import { getDelegate } from '../../utils/api/delegate';
 import { voteLookupStatusUpdated, voteToggled } from '../../actions/voting';
 import actionTypes from '../../constants/actions';
 import votingConst from '../../constants/voting';
+import { getTotalVotesCount } from './../../utils/voting';
 
 const updateLookupStatus = (store, list, username) => {
   store.dispatch(voteLookupStatusUpdated({
@@ -68,8 +69,7 @@ const checkVoteLimits = (store, action) => {
     store.dispatch(newAction);
   }
 
-  const voteCount = Object.keys(votes).filter(
-    key => (votes[key].confirmed && !votes[key].unconfirmed) || votes[key].unconfirmed).length;
+  const voteCount = getTotalVotesCount(votes);
   if (voteCount === votingConst.maxCountOfVotes + 1 &&
         currentVote.unconfirmed !== currentVote.confirmed) {
     const label = i18next.t('Maximum of {{n}} votes exceeded.', { n: votingConst.maxCountOfVotes });

--- a/src/utils/voting.js
+++ b/src/utils/voting.js
@@ -1,0 +1,13 @@
+
+const getVotedList = votes => (Object.keys(votes).filter(key => votes[key].confirmed));
+
+const getUnvoteList = votes => (Object.keys(votes).filter(
+  key => !votes[key].unconfirmed && votes[key].confirmed));
+
+const getVoteList = votes => (Object.keys(votes).filter(
+  key => votes[key].unconfirmed && !votes[key].confirmed));
+
+const getTotalVotesCount = votes => ((getVotedList(votes).length - getUnvoteList(votes).length)
+  + getVoteList(votes).length);
+
+export { getTotalVotesCount, getVotedList, getVoteList, getUnvoteList };


### PR DESCRIPTION
What's the problem?
The error toast was displayed despite being within vote limit 
https://github.com/LiskHQ/lisk-nano/issues/911

What did you do?
- Moved existing working logic from votingBar into util to reuse in both places

How can I test it?
- Having already voted for 100 delegates, remove one existing vote and add 2 more (so your total votes are 101/101)
- There should be no error Toast anynmore
- Adding one more vote should show error toast