### PR TITLE
Fix transaction and port bug on custom node - Closes #910

### DIFF
--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -3,6 +3,7 @@ import Lisk from 'lisk-js';
 import actionTypes from '../constants/actions';
 import { getNethash } from './../utils/api/nethash';
 import { errorToastDisplayed } from './toaster';
+import netHashes from '../constants/netHashes';
 
 const peerSet = (data, config) => ({
   data: Object.assign({
@@ -33,15 +34,15 @@ export const activePeerSet = data =>
       const { hostname, port, protocol } = new URL(addHttp(config.address));
 
       config.node = hostname;
-      config.port = port;
-      config.ssl = protocol === 'https';
+      config.ssl = protocol === 'https:';
+      config.port = port || (config.ssl ? 443 : 80);
     }
     if (config.testnet === undefined && config.port !== undefined) {
       config.testnet = config.port === '7000';
     }
     if (config.custom) {
       getNethash(Lisk.api(config)).then((response) => {
-        config.nethash = response.nethash;
+        config.testnet = response.nethash === netHashes.testnet;
         dispatch(peerSet(data, config));
       }).catch(() => {
         dispatch(errorToastDisplayed({ label: i18next.t('Unable to connect to the node') }));

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -43,6 +43,9 @@ export const activePeerSet = data =>
     if (config.custom) {
       getNethash(Lisk.api(config)).then((response) => {
         config.testnet = response.nethash === netHashes.testnet;
+        if (!config.testnet && response.nethash !== netHashes.mainnet) {
+          config.nethash = response.nethash;
+        }
         dispatch(peerSet(data, config));
       }).catch(() => {
         dispatch(errorToastDisplayed({ label: i18next.t('Unable to connect to the node') }));

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
 import actionTypes from '../constants/actions';
+import netHashes from '../constants/netHashes';
 import { activePeerSet, activePeerUpdate } from './peers';
 import * as nethashApi from './../utils/api/nethash';
 
@@ -63,7 +64,7 @@ describe('actions: peers', () => {
       expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.address', 'localhost:8000'));
     });
 
-    it('dispatch activePeerSet with nethash from response when the network is a custom node', () => {
+    it('dispatch activePeerSet with testnet config set to true when the network is a custom node and nethash is testnet', () => {
       getNetHash.returnsPromise();
       const network = {
         address: 'http://localhost:4000',
@@ -71,9 +72,22 @@ describe('actions: peers', () => {
       };
 
       activePeerSet({ passphrase, network })(dispatch);
-      getNetHash.resolves({ nethash: 'nethash from response' });
+      getNetHash.resolves({ nethash: netHashes.testnet });
 
-      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.nethash.nethash', 'nethash from response'));
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.testnet', true));
+    });
+
+    it('dispatch activePeerSet with testnet config set to false when the network is a custom node and nethash is testnet', () => {
+      getNetHash.returnsPromise();
+      const network = {
+        address: 'http://localhost:4000',
+        custom: true,
+      };
+
+      activePeerSet({ passphrase, network })(dispatch);
+      getNetHash.resolves({ nethash: 'some other nethash' });
+
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.testnet', false));
     });
 
     it('dispatch activePeerSet action even if network is undefined', () => {

--- a/src/constants/netHashes.js
+++ b/src/constants/netHashes.js
@@ -1,0 +1,5 @@
+const netHash = {
+  testnet: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+};
+
+export default netHash;

--- a/src/constants/netHashes.js
+++ b/src/constants/netHashes.js
@@ -1,5 +1,6 @@
 const netHash = {
   testnet: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+  mainnet: 'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
 };
 
 export default netHash;


### PR DESCRIPTION
What's the problem?
Sending transactions was not possible on custom node anymore. 
There were problems when no port was specified and with the version that was sent with the request.
https://github.com/LiskHQ/lisk-nano/issues/910

What did you do?
- Adjusted port when using https
- Corrected sent version when making request

How can I test it?
- Open Lisk Nano
- Login to "Custom node" https://testnet.lisk.io/
- Open "Send" dialog
- Fill in the form and submit it.
- Make sure the transaction actually appears in the list