### PR TITLE
Retain votes after cleaned search box - Closes #916

### DIFF
--- a/src/components/voteUrlProcessor/index.js
+++ b/src/components/voteUrlProcessor/index.js
@@ -5,8 +5,6 @@ import { withRouter } from 'react-router';
 import {
   urlVotesFound,
   voteLookupStatusCleared,
-  voteToggled,
-  votesAdded,
 } from '../../actions/voting';
 import VoteUrlProcessor from './voteUrlProcessor';
 
@@ -28,8 +26,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  voteToggled: data => dispatch(voteToggled(data)),
-  votesAdded: data => dispatch(votesAdded(data)),
   urlVotesFound: data => dispatch(urlVotesFound(data)),
   clearVoteLookupStatus: () => dispatch(voteLookupStatusCleared()),
 });

--- a/src/components/voteUrlProcessor/index.test.js
+++ b/src/components/voteUrlProcessor/index.test.js
@@ -42,20 +42,6 @@ describe('VoteUrlProcessorHOC', () => {
     expect(wrapper.find(VoteUrlProcessor)).to.have.lengthOf(1);
   });
 
-  it('should bind voteToggled action to VoteUrlProcessor props.voteToggled', () => {
-    const actionsSpy = sinon.spy(votingActions, 'voteToggled');
-    wrapper.find(VoteUrlProcessor).props().voteToggled(actionData);
-    expect(actionsSpy).to.be.calledWith(actionData);
-    actionsSpy.restore();
-  });
-
-  it('should bind votesAdded action to VoteUrlProcessor props.votesAdded', () => {
-    const actionsSpy = sinon.spy(votingActions, 'votesAdded');
-    wrapper.find(VoteUrlProcessor).props().votesAdded(actionData);
-    expect(actionsSpy).to.be.calledWith(actionData);
-    actionsSpy.restore();
-  });
-
   it('should bind urlVotesFound action to VoteUrlProcessor props.urlVotesFound', () => {
     const actionMock = sinon.mock(votingActions);
     actionMock.expects('urlVotesFound').withExactArgs(actionData).returns({ type: 'DUMMY' });

--- a/src/components/voteUrlProcessor/voteUrlProcessor.js
+++ b/src/components/voteUrlProcessor/voteUrlProcessor.js
@@ -21,7 +21,7 @@ export default class VoteUrlProcessor extends React.Component {
     }
   }
 
-  getProccessedCount() {
+  getProcessedCount() {
     return this.props.urlVoteCount - this.props.pending.length;
   }
 
@@ -42,13 +42,13 @@ export default class VoteUrlProcessor extends React.Component {
     };
     return (
       <div>
-        {this.getProccessedCount() < this.props.urlVoteCount ?
+        {this.getProcessedCount() < this.props.urlVoteCount ?
           (<div>
             <ProgressBar type='linear' mode='determinate'
-              value={this.getProccessedCount()} max={this.props.urlVoteCount}/>
+              value={this.getProcessedCount()} max={this.props.urlVoteCount}/>
             <div className={styles.center}>
               {this.props.t('Processing delegate names: ')}
-              {this.getProccessedCount()} / {this.props.urlVoteCount}
+              {this.getProcessedCount()} / {this.props.urlVoteCount}
             </div>
           </div>) :
           (<span>{Object.keys(errorMessages).map(list => (

--- a/src/components/voting/voting.js
+++ b/src/components/voting/voting.js
@@ -23,11 +23,10 @@ class Voting extends React.Component {
   }
 
   componentWillUpdate(nextProps) {
-    setTimeout(() => {
-      if (this.props.refreshDelegates) {
-        this.loadVotedDelegates(true);
-      }
-    }, 1);
+    if (!this.props.refreshDelegates && nextProps.refreshDelegates) {
+      this.loadVotedDelegates(true);
+    }
+
     if (this.props.delegates.length < nextProps.delegates.length) {
       setTimeout(() => {
         this.freezeLoading = false;


### PR DESCRIPTION
**What's the issue?**
Presently we keep the search term in Redux store, but at the time of developing this component we just kept vote list, delegates list and refresh flag. So now changes in the search term cause unintended trigger of `loadVotedDelegates`.

**How did I solve?**
Instead of listening for changes of properties, I check if `refreshDelegates` has been changed from `false` to `true`.

There are some other minor code cleanups in this PR.

Closes #916 