### PR TITLE
 Fix launch protocol on Linux - Closes #909

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -70,8 +70,8 @@ function createWindow() {
   win.on('blur', () => win.webContents.send('blur'));
   win.on('focus', () => win.webContents.send('focus'));
 
-  if (process.platform === 'win32') {
-    sendUrlToRouter(process.argv.slice(1));
+  if (process.platform !== 'darwin') {
+    sendUrlToRouter(process.argv[1] || '/');
   }
 
   Menu.setApplicationMenu(buildMenu(app, copyright, i18n));
@@ -142,8 +142,8 @@ app.setAsDefaultProtocolClient(protocolName);
 
 // Force single instance application
 const isSecondInstance = app.makeSingleInstance((argv) => {
-  if (process.platform === 'win32') {
-    sendUrlToRouter(argv.slice(1));
+  if (process.platform !== 'darwin') {
+    sendUrlToRouter(argv[1] || '/');
   }
   if (win) {
     if (win.isMinimized()) win.restore();

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "css-loader": "0.28.7",
     "cucumber": "2.2.0",
     "del-cli": "1.1.0",
-    "electron": "1.7.8",
+    "electron": "1.8.1",
     "electron-builder": "19.32.2",
     "electron-json-storage": "^3.2.0",
     "enzyme": "2.9.1",
@@ -149,7 +149,11 @@
         "deb",
         "rpm",
         "tar.gz"
-      ]
+      ],
+      "desktop": {
+        "MimeType": "application/lisk;x-scheme-handler/lisk"
+      },
+      "category": "Network"
     },
     "win": {
       "target": "nsis"


### PR DESCRIPTION
There are 3 parts of the fix:
- The same fix as in https://www.electron.build/configuration/linux#LinuxConfiguration-target
- Send the url from electron not only on windows platform.
- Setting MimeType as described in https://askubuntu.com/questions/514125/url-protocol-handlers-in-basic-ubuntu-desktop and https://www.electron.build/configuration/linux#LinuxConfiguration-target

Closes #909