### PR TITLE
Fix randomly failing delegate test - Closes #859

### DIFF
--- a/src/utils/api/account.test.js
+++ b/src/utils/api/account.test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { mock } from 'sinon';
 import { getAccount, setSecondPassphrase, send, transactions, unconfirmedTransactions,
   extractPublicKey, extractAddress } from './account';
-import { activePeerSet } from '../../actions/peers';
 
 describe('Utils: Account', () => {
   const address = '1449310910991872227L';
@@ -23,41 +22,29 @@ describe('Utils: Account', () => {
     });
 
     it('should return a promise that is resolved when activePeer.getAccount() calls its callback with data.success == true', () => {
-      const response = {
-        success: true,
-        balance: 0,
-      };
+      const account = { address, balance: 0 };
+      const response = { success: true, account };
+
       activePeerMock.expects('getAccount').withArgs(address).callsArgWith(1, response);
       const requestPromise = getAccount(activePeer, address);
-      expect(requestPromise).to.eventually.deep.equal(response);
+      return expect(requestPromise).to.eventually.eql(account);
     });
 
-    it('should return a promise that is resolved even when activePeer.getAccount() calls its callback with data.success == false', () => {
-      const response = {
-        success: false,
-        message: 'account doesn\'t exist',
-      };
-      const account = {
-        address,
-        balance: 0,
-      };
+    it('should return a promise that is resolved even when activePeer.getAccount() calls its callback with data.success == false and "Account not found"', () => {
+      const response = { success: false, error: 'Account not found' };
+      const account = { address, balance: 0 };
+
       activePeerMock.expects('getAccount').withArgs(address).callsArgWith(1, response);
       const requestPromise = getAccount(activePeer, address);
-      expect(requestPromise).to.eventually.deep.equal(account);
+      return expect(requestPromise).to.eventually.eql(account);
     });
 
-    it('it should resolve account info if available', () => {
-      const network = {
-        address: 'http://localhost:8000',
-        testnet: true,
-        name: 'Testnet',
-        nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-      };
+    it('should otherwise return a promise that is rejected', () => {
+      const response = { success: false };
 
-      const { data } = activePeerSet(network);
-      getAccount(data, address).then((result) => {
-        expect(result.balance).to.be.equal(0);
-      });
+      activePeerMock.expects('getAccount').withArgs(address).callsArgWith(1, response);
+      const requestPromise = getAccount(activePeer, address);
+      return expect(requestPromise).to.eventually.be.rejectedWith(response);
     });
   });
 

--- a/src/utils/api/delegate.test.js
+++ b/src/utils/api/delegate.test.js
@@ -38,53 +38,55 @@ describe('Utils: Delegate', () => {
   describe('listDelegates', () => {
     it('should return requestToActivePeer(activePeer, `delegates/`, options) if options = {}', () => {
       const options = {};
-      const mockedPromise = new Promise((resolve) => { resolve(); });
+      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/', options).returns(mockedPromise);
 
       const returnedPromise = listDelegates(activePeer, options);
-      expect(returnedPromise).to.equal(mockedPromise);
+      return expect(returnedPromise).to.eventually.equal('resolved promise');
     });
 
     it('should return requestToActivePeer(activePeer, `delegates/search`, options) if options.q is set', () => {
-      const options = {
-        q: 'genesis_1',
-      };
-      const mockedPromise = new Promise((resolve) => { resolve(); });
+      const options = { q: 'genesis_1' };
+      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', options).returns(mockedPromise);
 
       const returnedPromise = listDelegates(activePeer, options);
-      expect(returnedPromise).to.equal(mockedPromise);
+      return expect(returnedPromise).to.eventually.equal('resolved promise');
     });
   });
 
   describe('getDelegate', () => {
     it('should return requestToActivePeer(activePeer, `delegates/get`, options)', () => {
       const options = { publicKey: '"86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19"' };
-      const mockedPromise = new Promise((resolve) => { resolve(); });
+      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/get', options).returns(mockedPromise);
 
       const returnedPromise = getDelegate(activePeer, options);
-      expect(returnedPromise).to.equal(mockedPromise);
+      return expect(returnedPromise).to.eventually.equal('resolved promise');
     });
   });
 
   describe('unvoteAutocomplete', () => {
-    it('should return a promise', () => {
+    it('should return a promise that resolves an empty array when trying to unvote a non-existing user name', () => {
       const voteList = {
         genesis_1: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' },
         genesis_2: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' },
         genesis_3: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' },
       };
-      const nonExistingUsername = 'genesis_4';
-      const promise = unvoteAutocomplete(username, voteList);
-      expect(typeof promise.then).to.be.equal('function');
-      promise.then((result) => {
-        expect(result).to.be.equal(true);
-      });
 
-      unvoteAutocomplete(nonExistingUsername, voteList).then((result) => {
-        expect(result).to.be.equal(false);
-      });
+      const nonExistingUsername = 'genesis_4';
+      return expect(unvoteAutocomplete(nonExistingUsername, voteList)).to.eventually.eql([]);
+    });
+
+    it('should return a promise that resolves an array when trying to unvote an existing user name', () => {
+      const voteList = {
+        genesis_1: { confirmed: true, unconfirmed: true, publicKey: 'sample_key' },
+        genesis_2: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' },
+        genesis_3: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' },
+      };
+
+      const expectedResult = [{ username: 'genesis_1', publicKey: 'sample_key' }];
+      return expect(unvoteAutocomplete(username, voteList)).to.eventually.eql(expectedResult);
     });
   });
 
@@ -95,12 +97,12 @@ describe('Utils: Delegate', () => {
         secret: 'wagon dens',
         secondSecret: 'wagon dens',
       };
-      const mockedPromise = new Promise((resolve) => { resolve(); });
+      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data).returns(mockedPromise);
 
       const returnedPromise = registerDelegate(
         activePeer, data.username, data.secret, data.secondSecret);
-      expect(returnedPromise).to.equal(mockedPromise);
+      return expect(returnedPromise).to.eventually.equal('resolved promise');
     });
 
     it('should return requestToActivePeer(activePeer, `delegates`, data) even if no secondSecret specified', () => {
@@ -108,11 +110,11 @@ describe('Utils: Delegate', () => {
         username: 'test',
         secret: 'wagon dens',
       };
-      const mockedPromise = new Promise((resolve) => { resolve(); });
+      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data).returns(mockedPromise);
 
       const returnedPromise = registerDelegate(activePeer, data.username, data.secret);
-      expect(returnedPromise).to.equal(mockedPromise);
+      return expect(returnedPromise).to.eventually.equal('resolved promise');
     });
   });
 
@@ -137,11 +139,12 @@ describe('Utils: Delegate', () => {
         { username: 'genesis_42' },
         { username: 'genesis_44' },
       ];
-      const votedDict = { username: 'genesis_11' };
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', { q: username }).returns(Promise.resolve({ success: true, delegates }));
+      const votedDict = { genesis_3: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' } };
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', { q: username })
+        .returns(Promise.resolve({ success: true, delegates }));
 
       const returnedPromise = voteAutocomplete(activePeer, username, votedDict);
-      expect(returnedPromise).to.eventually.become({ success: true, delegates });
+      return expect(returnedPromise).to.eventually.eql(delegates);
     });
   });
 });

--- a/src/utils/api/delegate.test.js
+++ b/src/utils/api/delegate.test.js
@@ -38,8 +38,8 @@ describe('Utils: Delegate', () => {
   describe('listDelegates', () => {
     it('should return requestToActivePeer(activePeer, `delegates/`, options) if options = {}', () => {
       const options = {};
-      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/', options).returns(mockedPromise);
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/', options)
+        .returnsPromise().resolves('resolved promise');
 
       const returnedPromise = listDelegates(activePeer, options);
       return expect(returnedPromise).to.eventually.equal('resolved promise');
@@ -47,8 +47,8 @@ describe('Utils: Delegate', () => {
 
     it('should return requestToActivePeer(activePeer, `delegates/search`, options) if options.q is set', () => {
       const options = { q: 'genesis_1' };
-      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', options).returns(mockedPromise);
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', options)
+        .returnsPromise().resolves('resolved promise');
 
       const returnedPromise = listDelegates(activePeer, options);
       return expect(returnedPromise).to.eventually.equal('resolved promise');
@@ -58,8 +58,8 @@ describe('Utils: Delegate', () => {
   describe('getDelegate', () => {
     it('should return requestToActivePeer(activePeer, `delegates/get`, options)', () => {
       const options = { publicKey: '"86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19"' };
-      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/get', options).returns(mockedPromise);
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/get', options)
+        .returnsPromise().resolves('resolved promise');
 
       const returnedPromise = getDelegate(activePeer, options);
       return expect(returnedPromise).to.eventually.equal('resolved promise');
@@ -97,8 +97,8 @@ describe('Utils: Delegate', () => {
         secret: 'wagon dens',
         secondSecret: 'wagon dens',
       };
-      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data).returns(mockedPromise);
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data)
+        .returnsPromise().resolves('resolved promise');
 
       const returnedPromise = registerDelegate(
         activePeer, data.username, data.secret, data.secondSecret);
@@ -110,8 +110,8 @@ describe('Utils: Delegate', () => {
         username: 'test',
         secret: 'wagon dens',
       };
-      const mockedPromise = new Promise((resolve) => { resolve('resolved promise'); });
-      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data).returns(mockedPromise);
+      peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates', data)
+        .returnsPromise().resolves('resolved promise');
 
       const returnedPromise = registerDelegate(activePeer, data.username, data.secret);
       return expect(returnedPromise).to.eventually.equal('resolved promise');
@@ -141,7 +141,7 @@ describe('Utils: Delegate', () => {
       ];
       const votedDict = { genesis_3: { confirmed: true, unconfirmed: false, publicKey: 'sample_key' } };
       peersMock.expects('requestToActivePeer').withArgs(activePeer, 'delegates/search', { q: username })
-        .returns(Promise.resolve({ success: true, delegates }));
+        .returnsPromise().resolves({ success: true, delegates });
 
       const returnedPromise = voteAutocomplete(activePeer, username, votedDict);
       return expect(returnedPromise).to.eventually.eql(delegates);


### PR DESCRIPTION
What's the problem?
The delegate utils test 
`should return requestToActivePeer(activePeer, 'delegates/search', options) if options.q is set`
is randomly failing. The assumption is, that this is caused by non-proper promise testing in previous tests.
https://github.com/LiskHQ/lisk-nano/issues/859

What did you do?
- Corrected the account utils tests, that were not working and not dealing with promises correctly
- Also corrected the delegate utils tests, since these weren't correct either