### PR TITLE
Fix exception throwing - Close 942

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -39,9 +39,10 @@ const sendDetectedLang = (locale) => {
 // read config data from JSON file
 const getConfig = () => {
   storage.get('config', (error, data) => {
-    if (error) throw error;
-    lang = data.lang;
-    sendDetectedLang(lang);
+    if (!error) {
+      lang = data.lang;
+      sendDetectedLang(lang);
+    }
   });
 };
 


### PR DESCRIPTION
### What was the problem?
If file in `appData` folder is corrupted (`storage/config.json`) it causes an error on `Lisk Nano` launch.
It happens because `electron-json-storage` expects file with valid `json` format, but file can be empty.

### How did I fix it?
Remove `throw error` code.

### How to test it?
Try to open and close Lisk Nano many times before full loading is completed.

### Review checklist
- [x] The PR solves #942
- [x] All new code is covered with unit tests
- [x] All new features are covered with e2e tests
- [x] All new code follows best practices