### PR TITLE
Fix styles of encrypt/decrypt menu items - Closes #948

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -44,12 +44,12 @@ const Header = props => (
           <RelativeLink className={`verify-message ${styles.menuLink}`}
             to='verify-message'>{props.t('Verify message')}</RelativeLink>
         </MenuItem>
-        <MenuItem>
-          <RelativeLink className={`encrypt-message ${styles.menuItem}`}
+        <MenuItem theme={styles}>
+          <RelativeLink className={`encrypt-message ${styles.menuLink}`}
             to='encrypt-message'>{props.t('Encrypt message')}</RelativeLink>
         </MenuItem>
-        <MenuItem>
-          <RelativeLink className={`decrypt-message ${styles.menuItem}`}
+        <MenuItem theme={styles}>
+          <RelativeLink className={`decrypt-message ${styles.menuLink}`}
             to='decrypt-message'>{props.t('Decrypt message')}</RelativeLink>
         </MenuItem>
         <MenuDivider />


### PR DESCRIPTION
### What was the problem?
Encrypt/decrypt message was merged in 1.3.0 branch and all was good. But other changes were made in 1.2.0 to make the whole of menu items clickable. When these two got merged we got the problem described in #948

### How did I fix it?
By applying the same classes that are used in other menu items.

### How to test it?
Follow the steps to reproduce in #948

### Review checklist
- [ ] The PR solves #948 
- [ ] All new code follows best practices
