### PR TITLE
Remove direct calls to methods of components in unit tests - Closes #703

### DIFF
--- a/src/components/dialog/dialog.test.js
+++ b/src/components/dialog/dialog.test.js
@@ -46,7 +46,10 @@ describe('Dialog', () => {
   });
 
   it('should fix the route if there are two dialog names', () => {
-    wrapper.instance().componentDidUpdate();
+    const newProps = Object.assign({}, { dialog: dialogProps, history }, props);
+    newProps.dialog.title = 'Send1';
+    // trying to update the component
+    wrapper.setProps(newProps);
     expect(history.push).to.have.been.calledWith();
   });
 });

--- a/src/components/formattedNumber/index.js
+++ b/src/components/formattedNumber/index.js
@@ -4,10 +4,10 @@ import * as locales from 'numeral/locales'; // eslint-disable-line
 import { translate } from 'react-i18next';
 import i18n from '../../i18n';
 
-const FormattedNumber = (props) => {
+const FormattedNumber = ({ val }) => {
   // set numeral language
   numeral.locale(i18n.language);
-  const formatedNumber = numeral(props.val).format('0,0.[0000000000000]');
+  const formatedNumber = numeral(val).format('0,0.[0000000000000]');
   return <span>{formatedNumber}</span>;
 };
 

--- a/src/components/formattedNumber/index.test.js
+++ b/src/components/formattedNumber/index.test.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import FormattedNumber from './index';
+import i18n from '../../i18n';
+
+
+describe('FormattedNumber', () => {
+  const options = {
+    context: { i18n },
+    childContextTypes: {
+      i18n: PropTypes.object.isRequired,
+    },
+  };
+
+  it('renders 0 if raw value is 0', () => {
+    const value = {
+      raw: 0,
+      formatted: '0',
+    };
+    const wrapper = mount(<FormattedNumber val={value.raw} />, options);
+    expect(wrapper.find('span').text()).to.equal(value.formatted);
+  });
+
+  it('renders 1,000 if raw value is 1000', () => {
+    const value = {
+      raw: 1234,
+      formatted: '1,234',
+    };
+    const wrapper = mount(<FormattedNumber val={value.raw} />, options);
+    expect(wrapper.find('span').text()).to.equal(value.formatted);
+  });
+
+  it('renders 1,000.95 if raw value is 1000', () => {
+    const value = {
+      raw: 1234.56,
+      formatted: '1,234.56',
+    };
+    const wrapper = mount(<FormattedNumber val={value.raw} />, options);
+    expect(wrapper.find('span').text()).to.equal(value.formatted);
+  });
+
+  it('renders 10.01 if raw value is 10.01', () => {
+    const value = {
+      raw: 123.45,
+      formatted: '123.45',
+    };
+    const wrapper = mount(<FormattedNumber val={value.raw} />, options);
+    expect(wrapper.find('span').text()).to.equal(value.formatted);
+  });
+});

--- a/src/components/header/header.test.js
+++ b/src/components/header/header.test.js
@@ -49,7 +49,7 @@ describe('Header', () => {
     expect(wrapper.find(RelativeLink)).to.have.length(9);
   });
 
-  it('should have an image with srouce of "logo"', () => {
+  it('should have an image with source of "logo"', () => {
     expect(wrapper.contains(<img className={styles.logo} src={logo} alt="logo" />))
       .to.be.equal(true);
   });

--- a/src/components/loadingBar/loadingBar.test.js
+++ b/src/components/loadingBar/loadingBar.test.js
@@ -10,7 +10,7 @@ describe('LoadingBar Container', () => {
     expect(wrapper.find('ProgressBar')).to.have.lengthOf(1);
   });
 
-  it('should not show ProgresBar if props.loading.length is 0', () => {
+  it('should not show ProgressBar if props.loading.length is 0', () => {
     const wrapper = mount(<LoadingBar loading={[]} />);
     expect(wrapper.find('ProgressBar')).to.have.lengthOf(0);
   });

--- a/src/components/login/login.test.js
+++ b/src/components/login/login.test.js
@@ -11,6 +11,8 @@ import Login from './login';
 
 describe('Login', () => {
   let wrapper;
+  const address = 'http:localhost:8080';
+  const passphrase = 'recipe bomb asset salon coil symbol tiger engine assist pact pumpkin';
   // Mocking store
   const account = {
     isDelegate: false,
@@ -58,7 +60,6 @@ describe('Login', () => {
     });
 
     it('should show error about passphrase length if passphrase is have wrong length', () => {
-      const passphrase = 'recipe bomb asset salon coil symbol tiger engine assist pact pumpkin';
       const expectedError = 'Passphrase should have 12 words, entered passphrase has 11';
       wrapper.find('.passphrase input').simulate('change', { target: { value: ' ' } });
       wrapper.find('.passphrase input').simulate('change', { target: { value: passphrase } });
@@ -66,8 +67,7 @@ describe('Login', () => {
     });
   });
 
-  describe('componentDidUpdate', () => {
-    const address = 'http:localhost:8080';
+  describe('History management', () => {
     props.account = { address: 'dummy' };
 
     it('calls this.props.history.replace(\'/main/transactions\')', () => {
@@ -96,8 +96,13 @@ describe('Login', () => {
 
     it('calls localStorage.setItem(\'address\', address) if this.state.address', () => {
       const spyFn = spy(localStorage, 'setItem');
-      wrapper = shallow(<Login {...props}/>, options);
-      wrapper.setState({ address });
+      wrapper = mount(<Router><Login {...props}/></Router>, options);
+      // set the network dropdown
+      wrapper.find('div.network').simulate('click');
+      // select custom node
+      wrapper.find('div.network ul li').at(2).simulate('click');
+      // fill the address
+      wrapper.find('Input.address input').simulate('change', { target: { value: address } });
       wrapper.setProps(props);
       expect(spyFn).to.have.been.calledWith('address', address);
 
@@ -106,23 +111,17 @@ describe('Login', () => {
     });
   });
 
-  describe('changeHandler', () => {
-    it('call setState with matching data', () => {
-      wrapper = shallow(<Login {...props}/>, options);
-      const key = 'network';
-      const value = 0;
-      const spyFn = spy(Login.prototype, 'setState');
-      wrapper.instance().changeHandler(key, value);
-      expect(spyFn).to.have.been.calledWith({ [key]: value });
-    });
-  });
-
-  describe('onLoginSubmission', () => {
+  describe('After submission', () => {
     it('it should call activePeerSet', () => {
       const spyActivePeerSet = spy(props, 'activePeerSet');
 
-      wrapper = shallow(<Login {...props}/>, options);
-      wrapper.instance().onLoginSubmission();
+      wrapper = mount(<Router><Login {...props}/></Router>, options);
+      // Filling the login form
+      wrapper.find('div.network').simulate('click');
+      wrapper.find('div.network ul li').at(2).simulate('click');
+      wrapper.find('Input.address input').simulate('change', { target: { value: address } });
+      wrapper.find('Input.passphrase input').simulate('change', { target: { value: passphrase } });
+      wrapper.find('form').simulate('submit');
       expect(spyActivePeerSet).to.have.been.calledWith();
     });
   });

--- a/src/components/passphrase/passphraseGenerator.js
+++ b/src/components/passphrase/passphraseGenerator.js
@@ -38,12 +38,12 @@ class PassphraseGenerator extends React.Component {
 
   /**
    * Tests useragent with a regexp and defines if the account is mobile device
+   * it is on class so that we can mock it in unit tests
    *
    * @param {String} [agent] - The useragent string, This parameter is used for
    *  unit testing purpose
    * @returns {Boolean} - whether the agent represents a mobile device or not
    */
-  // it is on class so that we can mock it in unit tests
   // eslint-disable-next-line class-methods-use-this
   isTouchDevice(agent) {
     return (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(agent || navigator.userAgent || navigator.vendor || window.opera));
@@ -88,10 +88,11 @@ class PassphraseGenerator extends React.Component {
   }
 
   render() {
+    const isTouch = this.isTouchDevice(this.props.agent);
     return (
       <div className={`${grid.row} ${grid['center-xs']}`} >
         <div className={grid['col-xs-12']}>
-          {this.isTouchDevice() ?
+          {isTouch ?
             <div>
               <p>Enter text below to generate random bytes</p>
               <Input onChange={this.seedGeneratorBoundToThis}

--- a/src/components/passphrase/passphraseGenerator.test.js
+++ b/src/components/passphrase/passphraseGenerator.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
-import { spy, mock } from 'sinon';
-import { mount, shallow } from 'enzyme';
+import { spy } from 'sinon';
+import { mount } from 'enzyme';
 import PassphraseGenerator from './passphraseGenerator';
+import * as passphraseUtil from '../../utils/passphrase';
 
 
 describe('PassphraseGenerator', () => {
@@ -11,34 +12,14 @@ describe('PassphraseGenerator', () => {
       changeHandler: () => {},
       t: key => key,
     };
-    const mockEvent = {
-      pageX: 140,
-      pageY: 140,
-    };
-
-    it('calls setState to setValues locally', () => {
-      const wrapper = shallow(<PassphraseGenerator {...props}/>);
-      const spyFn = spy(wrapper.instance(), 'setState');
-      wrapper.instance().seedGenerator(mockEvent);
-      expect(spyFn).to.have.been.calledWith();
-      wrapper.instance().setState.restore();
-    });
 
     it('shows an Input fallback if this.isTouchDevice()', () => {
-      const wrapper = mount(<PassphraseGenerator {...props}/>);
-      const isTouchDeviceMock = mock(wrapper.instance()).expects('isTouchDevice');
-      isTouchDeviceMock.returns(true);
-      wrapper.instance().setState({}); // to rerender the component
-      wrapper.update();
+      const wrapper = mount(<PassphraseGenerator {...props} agent='ipad'/>);
       expect(wrapper.find('Input.touch-fallback textarea')).to.have.lengthOf(1);
     });
 
     it('shows at least some progress on pressing input if this.isTouchDevice()', () => {
-      const wrapper = mount(<PassphraseGenerator {...props}/>);
-      const isTouchDeviceMock = mock(wrapper.instance()).expects('isTouchDevice');
-      isTouchDeviceMock.returns(true).twice();
-      wrapper.instance().setState({}); // to rerender the component
-      wrapper.update();
+      const wrapper = mount(<PassphraseGenerator {...props} agent='ipad'/>);
       wrapper.find('Input.touch-fallback textarea').simulate('change', { target: { value: 'random key presses' } });
       expect(wrapper.find('ProgressBar').props().value).to.be.at.least(1);
     });
@@ -46,53 +27,28 @@ describe('PassphraseGenerator', () => {
     it('removes mousemove event listener in componentWillUnmount', () => {
       const wrapper = mount(<PassphraseGenerator {...props}/>);
       const documentSpy = spy(document, 'removeEventListener');
-      wrapper.instance().componentWillUnmount();
+      wrapper.unmount();
       expect(documentSpy).to.have.be.been.calledWith('mousemove');
       documentSpy.restore();
     });
 
-    it('sets "data" and "lastCaptured" if distance is over 120', () => {
-      const wrapper = shallow(<PassphraseGenerator {...props}/>);
-      wrapper.instance().seedGenerator(mockEvent);
+    it('should call generateSeed for every event triggered', () => {
+      const generateSeedSpy = spy(passphraseUtil, 'generateSeed');
+      const wrapper = mount(<PassphraseGenerator {...props} agent='ipad'/>);
+      wrapper.find('Input.touch-fallback textarea').simulate('change', { target: { value: 'random key presses' } });
 
-      expect(wrapper.instance().state.data).to.not.equal(undefined);
-      expect(wrapper.instance().state.lastCaptured).to.deep.equal({
-        x: 140,
-        y: 140,
-      });
+      expect(generateSeedSpy.callCount).to.be.equal(1);
     });
 
-    it('should do nothing if distance is bellow 120', () => {
-      const wrapper = shallow(<PassphraseGenerator {...props}/>);
-      const nativeEvent = {
-        pageX: 10,
-        pageY: 10,
-      };
-      wrapper.instance().seedGenerator(nativeEvent);
+    it('should call generatePassphrase after enough event passed', () => {
+      const generatePassphraseSpy = spy(passphraseUtil, 'generatePassphrase');
+      const wrapper = mount(<PassphraseGenerator {...props} agent='ipad'/>);
+      const input = wrapper.find('Input.touch-fallback textarea');
+      for (let i = 0; i < 101; i++) {
+        input.simulate('change', { target: { value: 'random key presses' } });
+      }
 
-      expect(wrapper.instance().state.data).to.be.equal(undefined);
-      expect(wrapper.instance().state.lastCaptured).to.deep.equal({
-        x: 0,
-        y: 0,
-      });
-    });
-
-    it('should generate passphrase if seed is completed', () => {
-      const wrapper = shallow(<PassphraseGenerator {...props}/>);
-      // set mock data
-      wrapper.instance().setState({
-        data: {
-          seed: ['e6', '3c', 'd1', '36', 'e9', '70', '5f',
-            'c0', '4d', '31', 'ef', 'b8', 'd6', '53', '48', '11'],
-          percentage: 100,
-          step: 1,
-          byte: [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0],
-        },
-      });
-
-      wrapper.instance().seedGenerator(mockEvent);
-
-      expect(wrapper.instance().state.passphrase).to.not.equal(undefined);
+      expect(generatePassphraseSpy.callCount).to.be.equal(1);
     });
   });
 });

--- a/src/components/passphrase/passphraseVerifier.js
+++ b/src/components/passphrase/passphraseVerifier.js
@@ -13,7 +13,8 @@ class PassphraseConfirmator extends React.Component {
 
   componentDidMount() {
     this.props.updateAnswer(false);
-    this.hideRandomWord.call(this);
+    // this.props.randomIndex is used in unit teasing
+    this.hideRandomWord.call(this, this.props.randomIndex);
   }
 
   hideRandomWord(rand = Math.random()) {
@@ -40,7 +41,7 @@ class PassphraseConfirmator extends React.Component {
     return (
       <div className={`passphrase-verifier ${grid.row} ${grid['start-xs']}`}>
         <div className={grid['col-xs-12']}>
-          <p>
+          <p className='passphrase-holder'>
             <span>{this.state.passphraseParts[0]}</span>
             <span className={styles.missing}>-----</span>
             <span>{this.state.passphraseParts[1]}</span>

--- a/src/components/spinner/index.test.js
+++ b/src/components/spinner/index.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import Spinner from './index';
 
 describe('Spinner', () => {
-  it('should render 1 span and 3 divs', () => {
+  it('should render 1 span and 3 div tags', () => {
     const wrapper = mount(<Spinner />);
     expect(wrapper.find('span')).to.have.lengthOf(1);
     expect(wrapper.find('div')).to.have.lengthOf(3);

--- a/src/components/toaster/toaster.test.js
+++ b/src/components/toaster/toaster.test.js
@@ -5,7 +5,6 @@ import { mount } from 'enzyme';
 import Toaster from './toaster';
 
 describe('Toaster', () => {
-  let wrapper;
   const toasts = [{
     label: 'test',
     type: 'success',
@@ -16,25 +15,33 @@ describe('Toaster', () => {
     hideToast: sinon.spy(),
   };
 
-  beforeEach(() => {
-    wrapper = mount(<Toaster {...toasterProps} />);
-  });
-
   it('renders <Snackbar /> component from react-toolbox', () => {
+    const wrapper = mount(<Toaster {...toasterProps} />);
     expect(wrapper.find('Snackbar')).to.have.length(1);
   });
 
   describe('hideToast', () => {
     it('hides the toast and after the animation ends calls this.props.hideToast()', () => {
+      document.body.prepend(document.createElement('div'));
       const clock = sinon.useFakeTimers({
         toFake: ['setTimeout', 'clearTimeout', 'Date'],
       });
-      wrapper.instance().hideToast(toasts[0]);
-      expect(wrapper.state('hidden')).to.deep.equal({ [toasts[0].index]: true });
-      clock.tick(510);
-      expect(wrapper.state('hidden')).to.deep.equal({ [toasts[0].index]: false });
-      clock.restore();
+      mount(<Toaster {...toasterProps} />, { attachTo: document.body.firstChild });
+      let toastElement = document.getElementsByClassName('toast');
+
+      // check if the toast is activated
+      expect(toastElement.length > 0 &&
+        toastElement[0].className.indexOf('active') > 0)
+        .to.equal(true);
+
+      clock.tick(4510);
+
+      // check if the toast is deactivated
+      toastElement = document.getElementsByClassName('toast');
+
+      // check if hideToast is called
       expect(toasterProps.hideToast).to.have.been.calledWith(toasts[0]);
+      clock.restore();
     });
   });
 });

--- a/src/components/voteDialog/voteAutocomplete.js
+++ b/src/components/voteDialog/voteAutocomplete.js
@@ -208,14 +208,14 @@ export class VoteAutocompleteRaw extends React.Component {
         </div>
         <section className={styles.searchContainer}>
           <Input type='text' label={this.props.t('Search by username')} name='votedListSearch'
-            className='votedListSearch' value={this.state.votedListSearch}
+            className='votedListSearch vote-auto-complete' value={this.state.votedListSearch}
             error={this.state.votedSuggestionError}
             theme={styles}
             onBlur={this.suggestionStatus.bind(this, false, 'votedSuggestionClass')}
             onKeyDown={this.votedSearchKeyDown.bind(this)}
             onChange={this.search.bind(this, 'votedListSearch')}
             autoComplete='off'/>
-          <Card id='votedResult' className={`${styles.searchResult} ${this.state.votedSuggestionClass}`}>
+          <Card id='votedResult' className={`vote-auto-complete-list ${styles.searchResult} ${this.state.votedSuggestionClass}`}>
             <List>
               {this.state.votedResult.map(
                 item => <ListItem
@@ -249,7 +249,7 @@ export class VoteAutocompleteRaw extends React.Component {
             onKeyDown={this.unvotedSearchKeyDown.bind(this)}
             onChange={this.search.bind(this, 'unvotedListSearch')}
             autoComplete='off'/>
-          <Card id='unvotedResult' className={`${styles.searchResult} ${this.state.unvotedSuggestionClass}`}>
+          <Card id='unvotedResult' className={`unvote-auto-complete-list ${styles.searchResult} ${this.state.unvotedSuggestionClass}`}>
             <List>
               {this.state.unvotedResult.map(
                 item => <ListItem

--- a/src/components/voteDialog/voteAutocomplete.test.js
+++ b/src/components/voteDialog/voteAutocomplete.test.js
@@ -86,8 +86,7 @@ describe('VoteAutocomplete', () => {
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('change', { target: { value: 'user' } });
 
     clock.tick(400);
-    const reg = /><\/ul>/;
-    expect(reg.test(wrapper.find('Card .vote-auto-complete-list ul').html())).to.be.equal(true);
+    expect(wrapper.find('Card .vote-auto-complete-list ul')).to.be.blank();
     voteAutocompleteApiStub.restore();
   });
 
@@ -166,7 +165,7 @@ describe('VoteAutocomplete', () => {
     });
   });
 
-  it('should let you navigate and choose one of the options by arrow up/down', () => {
+  it('should let you navigate and choose one of the options in voteList using arrow up/down', () => {
     const voteAutocompleteApiStub = sinon.stub(delegateApi, 'voteAutocomplete');
     voteAutocompleteApiStub.returnsPromise().resolves(unvotedDelegate);
     // write a username
@@ -205,8 +204,7 @@ describe('VoteAutocomplete', () => {
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('keyDown', { keyCode: keyCodes.escape });
     voteAutocompleteApiStub.restore();
     clock.tick(400);
-    const reg = /><\/ul>/;
-    expect(reg.test(wrapper.find('Card .vote-auto-complete-list ul').html())).to.be.equal(true);
+    expect(wrapper.find('Card .vote-auto-complete-list').at(0).prop('className')).to.include('hidden');
   });
 
   it('should remove suggestion list if you clean the input', () => {
@@ -215,12 +213,12 @@ describe('VoteAutocomplete', () => {
     // write a username
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('change', { target: { value: 'user' } });
     clock.tick(400);
+    wrapper.update();
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('change', { target: { value: '' } });
-    clock.tick(400);
     voteAutocompleteApiStub.restore();
     clock.tick(400);
-    const reg = /><\/ul>/;
-    expect(reg.test(wrapper.find('Card .vote-auto-complete-list ul').html())).to.be.equal(true);
+    wrapper.update();
+    expect(wrapper.find('Card .vote-auto-complete-list ul')).to.be.blank();
   });
 
   it('should hide suggestion list if you blur the input', () => {
@@ -230,11 +228,10 @@ describe('VoteAutocomplete', () => {
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('change', { target: { value: 'user' } });
     clock.tick(400);
     wrapper.find('.votedListSearch.vote-auto-complete input').simulate('blur', {});
-    clock.tick(400);
     voteAutocompleteApiStub.restore();
-    clock.tick(400);
-    const reg = /><\/ul>/;
-    expect(reg.test(wrapper.find('Card .vote-auto-complete-list ul').html())).to.be.equal(true);
+    clock.tick(200);
+    wrapper.update();
+    expect(wrapper.find('Card .vote-auto-complete-list').at(0).prop('className')).to.include('hidden');
   });
 
   it('should suggest with full username to unvote if finds a voted delegate with a username starting with given string', () => {
@@ -243,12 +240,11 @@ describe('VoteAutocomplete', () => {
     wrapper.find('.unvotedListSearch input').simulate('change', { target: { value: 'user' } });
 
     clock.tick(300);
-    expect(wrapper.find('Card .unvote-auto-complete-list ul').html()
-      .indexOf(delegates[1].username)).to.be.greaterThan(-1);
+    expect(wrapper.find('Card .unvote-auto-complete-list ul').html()).to.include(delegates[1].username);
     unvoteAutocompleteApiStub.restore();
   });
 
-  it('should let you navigate and choose one of the options by arrow up/down', () => {
+  it('should let you navigate and choose one of the options in unvoteList using arrow up/down', () => {
     const unvoteAutocompleteApiStub = sinon.stub(delegateApi, 'unvoteAutocomplete');
     unvoteAutocompleteApiStub.returnsPromise().resolves([delegates[1]]);
     // write a username


### PR DESCRIPTION
### What was the problem?
Preferred is not to call any component method directly in unit tests. same goes for `setState` and other react related methods.

### How did I fix it?
I'm using enzyme event simulation to trigger all the required changes to test the methods of our components.

### How to test it?
Check the code syntax in unit tests. there should be no call for `setState`, `wrapper.instance` or any of the direct methods of the components.

### Review checklist
- [x] The PR solves #703 
- [x] None of our existing unit tests use `setState`, `wrapper.instance`.
- [x] All new code is covered with unit tests
- [x] All new code follows best practices
