### PR TITLE
Fix broken "save account" e2e scenario - Closes #957

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -129,7 +129,7 @@ class Login extends React.Component {
     const { savedAccounts } = this.props;
     if (savedAccounts && savedAccounts.length > 0 && !this.props.account.afterLogout) {
       this.account = savedAccounts[0];
-      const network = Object.assign({}, getNetwork(this.state.network));
+      const network = Object.assign({}, getNetwork(this.account.network));
       if (this.account.network === networks.customNode.code) {
         network.address = this.account.address;
       }


### PR DESCRIPTION
### What was the problem?
`Scenario: should allow to save account locally, after page reload it should require passphrase to do the first transaction, and remember the passphrase for next transactions` was failing
### How did I fix it?
By fixing the logic for getting network from the saved account.

### How to test it?
`npm run e2e-test -s -- --specs features/accountManagement.feature:2`

### Review checklist
- [ ] The PR solves #957
- [ ] None of our existing unit tests use `setState`, `wrapper.instance`.
- [ ] All new code is covered with unit tests
- [ ] All new code follows best practices