### PR TITLE
Setup testnet tests - Closes #925

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,15 +120,15 @@ node('lisk-nano') {
         ansiColor('xterm') {
           sh '''
           N=${EXECUTOR_NUMBER:-0}
-          passphrase=${env.TESTNET_PASSPHRASE}
 
           # End to End test configuration
           export DISPLAY=:1$N
           Xvfb :1$N -ac -screen 0 1280x1024x24 &
 
           # Run end-to-end tests
-          npm run --silent e2e-test:testnet:custom -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N  --params.testnetPassphrase $passphrase --params.testnetCustomNode true
-          npm run --silent e2e-test:testnet -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N --params.testnetPassphrase $passphrase
+
+          npm run --silent e2e-test:testnet:custom -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N --params.testnetCustomNode true
+          npm run --silent e2e-test:testnet -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N $TESTNET_PASSPHRASE
           npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N
           '''
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,19 +118,21 @@ node('lisk-nano') {
     stage ('Start Dev Server and Run E2E Tests') {
       try {
         ansiColor('xterm') {
-          sh '''
-          N=${EXECUTOR_NUMBER:-0}
+          withCredentials([string(credentialsId: 'lisk-nano-testnet-passphrase', variable: 'TESTNET_PASSPHRASE')]) {
+            sh '''
+            N=${EXECUTOR_NUMBER:-0}
 
-          # End to End test configuration
-          export DISPLAY=:1$N
-          Xvfb :1$N -ac -screen 0 1280x1024x24 &
+            # End to End test configuration
+            export DISPLAY=:1$N
+            Xvfb :1$N -ac -screen 0 1280x1024x24 &
 
-          # Run end-to-end tests
+            # Run end-to-end tests
 
-          npm run --silent e2e-test:testnet:custom -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N --params.testnetCustomNode true
-          npm run --silent e2e-test:testnet -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N $TESTNET_PASSPHRASE
-          npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N
-          '''
+            npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL https://testnet.lisk.io --cucumberOpts.tags @testnet --params.useTestnetPassphrase true
+            npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N --cucumberOpts.tags @testnet --params.useTestnetPassphrase true --params.network testnet
+            npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N
+            '''
+          }
         }
       } catch (err) {
         echo "Error: ${err}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,12 +120,15 @@ node('lisk-nano') {
         ansiColor('xterm') {
           sh '''
           N=${EXECUTOR_NUMBER:-0}
+          passphrase=${env.TESTNET_PASSPHRASE}
 
           # End to End test configuration
           export DISPLAY=:1$N
           Xvfb :1$N -ac -screen 0 1280x1024x24 &
 
           # Run end-to-end tests
+          npm run --silent e2e-test:testnet:custom -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N  --params.testnetPassphrase $passphrase --params.testnetCustomNode true
+          npm run --silent e2e-test:testnet -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N --params.testnetPassphrase $passphrase
           npm run --silent e2e-test -- --params.baseURL file://$WORKSPACE/app/build/index.html --params.liskCoreURL http://127.0.0.1:400$N
           '''
         }

--- a/features/send.feature
+++ b/features/send.feature
@@ -1,4 +1,5 @@
 Feature: Send dialog
+  @testnet
   Scenario: should allow to send when enough funds and correct address form
     Given I'm logged in as "genesis"
     When I click "send button"

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -19,18 +19,6 @@ const expect = chai.expect;
 const EC = protractor.ExpectedConditions;
 const defaultTimeout = 10 * 1000;
 
-const getNetworkType = (browser) => {
-  if (browser.params.testnetCustomNode) return 'customTestnet';
-  if (browser.params.testnet) return 'testnet';
-
-  return 'custom';
-};
-const getPassphrase = (browser, accountName) => ({
-  customTestnet: () => browser.params.testnetPassphrase,
-  testnet: () => browser.params.testnetPassphrase,
-  custom: () => accounts[accountName].passphrase,
-}[getNetworkType(browser)]);
-
 defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
   setDefaultTimeout(defaultTimeout);
 
@@ -152,7 +140,11 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
 
   Given('I\'m logged in as "{accountName}"', { timeout: 2 * defaultTimeout }, (accountName, callback) => {
     browser.get(browser.params.baseURL);
-    waitForElemAndSendKeys('.passphrase input', (getPassphrase(browser)()), () => {
+    const passphrase = browser.params.useTestnetPassphrase
+      ? browser.params.testnetPassphrase
+      : accounts[accountName].passphrase;
+
+    waitForElemAndSendKeys('.passphrase input', passphrase, () => {
       waitForElemAndClickIt('.login-button', callback);
     });
   });

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -19,6 +19,18 @@ const expect = chai.expect;
 const EC = protractor.ExpectedConditions;
 const defaultTimeout = 10 * 1000;
 
+const getNetworkType = (browser) => {
+  if (browser.params.testnetCustomNode) return 'customTestnet';
+  if (browser.params.testnet) return 'testnet';
+
+  return 'custom';
+};
+const getPassphrase = (browser, accountName) => ({
+  customTestnet: () => browser.params.testnetPassphrase,
+  testnet: () => browser.params.testnetPassphrase,
+  custom: () => accounts[accountName].passphrase,
+}[getNetworkType(browser)]);
+
 defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
   setDefaultTimeout(defaultTimeout);
 
@@ -140,7 +152,7 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
 
   Given('I\'m logged in as "{accountName}"', { timeout: 2 * defaultTimeout }, (accountName, callback) => {
     browser.get(browser.params.baseURL);
-    waitForElemAndSendKeys('.passphrase input', (browser.params.testnetPassphrase || accounts[accountName].passphrase), () => {
+    waitForElemAndSendKeys('.passphrase input', (getPassphrase(browser)()), () => {
       waitForElemAndClickIt('.login-button', callback);
     });
   });

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -140,7 +140,7 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
 
   Given('I\'m logged in as "{accountName}"', { timeout: 2 * defaultTimeout }, (accountName, callback) => {
     browser.get(browser.params.baseURL);
-    waitForElemAndSendKeys('.passphrase input', accounts[accountName].passphrase, () => {
+    waitForElemAndSendKeys('.passphrase input', (browser.params.testnetPassphrase || accounts[accountName].passphrase), () => {
       waitForElemAndClickIt('.login-button', callback);
     });
   });

--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -33,8 +33,8 @@ function takeScreenshot(screnarioSlug, callback) {
 }
 
 const getNetworkType = (browser) => {
-  if (browser.params.testnetPassphrase && browser.params.testnetCustomNode) return 'customTestnet';
-  if (browser.params.testnetPassphrase) return 'testnet';
+  if (browser.params.testnetCustomNode) return 'customTestnet';
+  if (browser.params.testnet) return 'testnet';
 
   return 'custom';
 };

--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -32,6 +32,21 @@ function takeScreenshot(screnarioSlug, callback) {
   });
 }
 
+const getNetworkType = (browser) => {
+  if (browser.params.testnetPassphrase && browser.params.testnetCustomNode) return 'customTestnet';
+  if (browser.params.testnetPassphrase) return 'testnet';
+
+  return 'custom';
+};
+const setNetwork = {
+  custom: () => { localStorage.setItem('network', 2); },
+  testnet: () => { localStorage.setItem('network', 1); },
+  customTestnet: () => {
+    localStorage.setItem('address', 'https://testnet.lisk.io');
+    localStorage.setItem('network', 2);
+  },
+};
+
 defineSupportCode(({ Before, After }) => {
   Before((scenario, callback) => {
     browser.ignoreSynchronization = true;
@@ -39,7 +54,7 @@ defineSupportCode(({ Before, After }) => {
     browser.get(browser.params.baseURL);
     localStorage.clear();
     localStorage.setItem('address', browser.params.liskCoreURL);
-    localStorage.setItem('network', 2);
+    setNetwork[getNetworkType(browser)]();
     callback();
   });
 

--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -2,6 +2,7 @@
 const { defineSupportCode } = require('cucumber');
 const fs = require('fs');
 const localStorage = require('../support/localStorage.js');
+const networks = require('./../../src/constants/networks');
 
 function slugify(text) {
   return text.toString().toLowerCase()
@@ -32,21 +33,6 @@ function takeScreenshot(screnarioSlug, callback) {
   });
 }
 
-const getNetworkType = (browser) => {
-  if (browser.params.testnetCustomNode) return 'customTestnet';
-  if (browser.params.testnet) return 'testnet';
-
-  return 'custom';
-};
-const setNetwork = {
-  custom: () => { localStorage.setItem('network', 2); },
-  testnet: () => { localStorage.setItem('network', 1); },
-  customTestnet: () => {
-    localStorage.setItem('address', 'https://testnet.lisk.io');
-    localStorage.setItem('network', 2);
-  },
-};
-
 defineSupportCode(({ Before, After }) => {
   Before((scenario, callback) => {
     browser.ignoreSynchronization = true;
@@ -54,7 +40,7 @@ defineSupportCode(({ Before, After }) => {
     browser.get(browser.params.baseURL);
     localStorage.clear();
     localStorage.setItem('address', browser.params.liskCoreURL);
-    setNetwork[getNetworkType(browser)]();
+    localStorage.setItem('network', networks[browser.params.network].code);
     callback();
   });
 

--- a/features/voting.feature
+++ b/features/voting.feature
@@ -67,6 +67,7 @@ Feature: Voting tab
     And I click checkbox on table row no. 5
     And I should see no "voting bar"
 
+  @testnet
   Scenario: should allow to select delegates in the "Voting" tab and vote for them
     Given I'm logged in as "delegate candidate"
     When I click tab number 2

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "build-prod": "webpack --config ./config/webpack.config.prod --env.prod",
     "build-electron": "webpack --config ./config/webpack.config.electron",
     "e2e-test": "protractor protractor.conf.js",
-    "e2e-test:testnet": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\" \"--params.testnet=true\"",
-    "e2e-test:testnet:custom": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\" \"--params.testnetCustomNode=true\"",
     "test": "karma start",
     "test-live": "npm test -- --auto-watch --no-single-run",
     "start": "electron ./app/",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-prod": "webpack --config ./config/webpack.config.prod --env.prod",
     "build-electron": "webpack --config ./config/webpack.config.electron",
     "e2e-test": "protractor protractor.conf.js",
+    "e2e-test:testnet": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\"",
     "test": "karma start",
     "test-live": "npm test -- --auto-watch --no-single-run",
     "start": "electron ./app/",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-prod": "webpack --config ./config/webpack.config.prod --env.prod",
     "build-electron": "webpack --config ./config/webpack.config.electron",
     "e2e-test": "protractor protractor.conf.js",
-    "e2e-test:testnet": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\"",
+    "e2e-test:testnet": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\" \"--params.testnet=true\"",
     "e2e-test:testnet:custom": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\" \"--params.testnetCustomNode=true\"",
     "test": "karma start",
     "test-live": "npm test -- --auto-watch --no-single-run",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-electron": "webpack --config ./config/webpack.config.electron",
     "e2e-test": "protractor protractor.conf.js",
     "e2e-test:testnet": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\"",
+    "e2e-test:testnet:custom": "protractor protractor.conf.js \"--specs=features/send.feature:2:17,features/voting.feature:70\" \"--params.testnetCustomNode=true\"",
     "test": "karma start",
     "test-live": "npm test -- --auto-watch --no-single-run",
     "start": "electron ./app/",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -24,7 +24,8 @@ exports.config = {
     screenshotFolder: 'e2e-test-screenshots',
     baseURL: 'http://localhost:8080/',
     liskCoreURL: 'http://localhost:4000/',
-    testnetPassphrase: null,
+    testnetPassphrase: process.env.TESTNET_PASSPHRASE,
     testnetCustomNode: false,
+    testnet: false,
   },
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -14,7 +14,7 @@ exports.config = {
 
   cucumberOpts: {
     require: 'features/step_definitions/*.js',
-    tags: '~@ignore',
+    tags: [],
     format: 'pretty',
     profile: false,
     'no-source': true,
@@ -25,7 +25,7 @@ exports.config = {
     baseURL: 'http://localhost:8080/',
     liskCoreURL: 'http://localhost:4000/',
     testnetPassphrase: process.env.TESTNET_PASSPHRASE,
-    testnetCustomNode: false,
-    testnet: false,
+    useTestnetPassphrase: false,
+    network: 'customNode',
   },
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -24,5 +24,7 @@ exports.config = {
     screenshotFolder: 'e2e-test-screenshots',
     baseURL: 'http://localhost:8080/',
     liskCoreURL: 'http://localhost:4000/',
+    testnetPassphrase: null,
+    testnetCustomNode: false,
   },
 };

--- a/src/constants/networks.js
+++ b/src/constants/networks.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   mainnet: { // network name translation t('Mainnet');
     name: 'Mainnet',
     ssl: true,


### PR DESCRIPTION
### What was the problem?
We had no configuration for running tests with testnet

### How did I fix it?
- Added scripts so we can run some of the existing voting and sending tests with testnet 

### How to test it?
Before you run the tests, you should save the passphrase in your env
`export TESTNET_PASSPHRASE='recipe bomb asset salon coil symbol tiger engine assist pact pumpkin visit'`
- Then, in order to just run tests with testnet you can go:
`npm run e2e-test -- --disableChecks --cucumberOpts.tags=@testnet --params.network=testnet --params.useTestnetPassphrase=true`
- In order to run tests with the custom node "https://testnet.lisk.io" you can go:
`npm run e2e-test -- --disableChecks --cucumberOpts.tags=@testnet -- --params.liskCoreURL=https://testnet.lisk.io --params.useTestnetPassphrase=true`

- Make also sure that the normal tests still work:
`npm run e2e-test`

### Review checklist
- [ ] The PR solves https://github.com/LiskHQ/lisk-nano/issues/925
- [ ] All new code follows best practices
