### PR TITLE
Set meta viewport to fix size on mobile devices

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,user-scalable=no">
         <title>Lisk Nano</title>
         <link rel="stylesheet" href="./styles.css">
         <link rel="icon" type="image/png" href="./assets/images/LISK.png" />


### PR DESCRIPTION
### What was the problem?
Lisk Nano was not scaled correctly on a phone. You can see it e.g. here:
https://jenkins.lisk.io/test/lisk-nano/development
### How did I fix it?
By adding meta viewport tag.
### How to test it?
Open https://jenkins.lisk.io/test/lisk-nano/meta-viewport on a phone.
