### PR TITLE
Cleanup eslint paths

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+coverage
+app/build

--- a/config/webpack.config.react.js
+++ b/config/webpack.config.react.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const { resolve } = require('path');
-const webpack = require('webpack');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const I18nScannerPlugin = require('../src/i18n-scanner');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "copy-files": "cpx \"./src/{index.html,assets/**/*}\" ./app/build/",
     "clean-build": "rm -rf app/build",
     "clean-dist": "rm -rf dist",
-    "eslint": "eslint ./src/ ./app/src/ ./app/config/ ./features/",
+    "eslint": "eslint ./",
     "pack": "npm install && npm run build && npm run clean-dist && npm run dist",
     "pack:win": "cmd /c npm install && npm run clean-build && npm run copy-files && npm run build-prod && npm run build-electron && npm run clean-dist && npm run dist:win",
     "storybook": "start-storybook -p 6006 -s ./src/",


### PR DESCRIPTION
### What was the problem?
Eslint specified paths it should cover instead of paths it should ignore. It didn't cover `./config/`
### How did I fix it?
by creating `.eslintignore` file and running `eslint ./`
### How to test it?
`npm run eslint`


