### PR TITLE
Remove outdated labels from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def fail(reason) {
 properties([disableConcurrentBuilds(), pipelineTriggers([])])
 node('lisk-nano') {
   try {
-    stage ('Cleanup, Checkout and Start Lisk Core') {
+    stage ('Checkout and Start Lisk Core') {
       try {
         deleteDir()
         checkout scm
@@ -111,7 +111,7 @@ node('lisk-nano') {
       }
     }
 
-    stage ('Start Dev Server and Run E2E Tests') {
+    stage ('Run E2E Tests') {
       try {
         ansiColor('xterm') {
           withCredentials([string(credentialsId: 'lisk-nano-testnet-passphrase', variable: 'TESTNET_PASSPHRASE')]) {


### PR DESCRIPTION
### What was the problem?
Some of the labels in Jenkinsfile were outdated
### How did I fix it?
I removed outdated labels from Jenkinsfile
### How to test it?
See the build in Jenkins
