### PR TITLE
Do not show delegate registration form for a delegate - Closes #946 

### DIFF
--- a/i18n/locales/de/common.json
+++ b/i18n/locales/de/common.json
@@ -175,6 +175,7 @@
   "You can vote for up to {{count}} delegates in total.": "Du kannst insgesamt für {{count}} Delegierte stimmen.",
   "You can vote for up to {{count}} delegates in total._plural": "Bis zu {{count}} Delegierte können insgesamt von einem Konto gewählt werden.",
   "You have not forged any blocks yet": "Du hast noch keine Blöcke geforged",
+  "You have already registered as a delegate.": "Du hast bereits als Delegierter registriert.",
   "You need to become a delegate to start forging. If you already registered to become a delegate, your registration hasn't been processed, yet.": "Um Blöcke forgen (erstellen) zu können, musst du Delegierter werden. Wenn du dich schon als Delegierter registriert hast, wurde deine Registrierung noch nicht verarbeitet.",
   "You've received {{value}} LSK.": "Du hast {{value}} LSK erhalten.",
   "Your transaction of {{amount}} LSK to {{recipientAddress}} was accepted and will be processed in a few seconds.": "Deine Transaktion von {{amount}} LSK zu {{recipientAddress}} wurde akzeptiert und wird in wenigen Sekunden verarbeitet.",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -183,6 +183,7 @@
   "You can select up to {{count}} delegates in one voting turn._plural": "You can select up to {{count}} delegates in one voting turn.",
   "You can vote for up to {{count}} delegates in total.": "You can vote for up to {{count}} delegates in total.",
   "You can vote for up to {{count}} delegates in total._plural": "You can vote for up to {{count}} delegates in total.",
+  "You have already registered as a delegate.": "You have already registered as a delegate.",
   "You have not forged any blocks yet": "You have not forged any blocks yet",
   "You need to become a delegate to start forging. If you already registered to become a delegate, your registration hasn't been processed, yet.": "You need to become a delegate to start forging. If you already registered to become a delegate, your registration hasn't been processed, yet.",
   "You've received {{value}} LSK.": "You've received {{value}} LSK.",

--- a/src/components/registerDelegate/registerDelegate.js
+++ b/src/components/registerDelegate/registerDelegate.js
@@ -17,6 +17,7 @@ class RegisterDelegate extends React.Component {
       ...authStatePrefill(),
     };
   }
+
   componentDidMount() {
     const newState = {
       name: {
@@ -40,6 +41,16 @@ class RegisterDelegate extends React.Component {
   }
 
   render() {
+    if (this.props.account.isDelegate) {
+      return (
+        <div>
+          <InfoParagraph>
+            {this.props.t('You have already registered as a delegate.')}
+          </InfoParagraph>
+        </div>
+      );
+    }
+
     return (
       <div>
         <form onSubmit={this.register.bind(this)}>

--- a/src/components/registerDelegate/registerDelegate.test.js
+++ b/src/components/registerDelegate/registerDelegate.test.js
@@ -151,9 +151,12 @@ describe('RegisterDelegate', () => {
       </Provider>);
     });
 
-    it('does not allow register as delegate for a delegate account', () => {
-      wrapper.find('.username input').simulate('change', { target: { value: 'sample_username' } });
-      expect(wrapper.find('.primary-button button').props().disabled).to.be.equal(true);
+    it('renders an InfoParagraph component', () => {
+      expect(wrapper.find('InfoParagraph')).to.have.length(1);
+    });
+
+    it('does not render the delegate registration form for registering', () => {
+      expect(wrapper.find('form')).to.have.length(0);
     });
   });
 });


### PR DESCRIPTION
### What was the problem?
An existing delegate was able to navigate directly to the register delegate dialog at `/main/voting/register-delegate` and view the delegate registration form.

### How did I fix it?
An informational dialog is displayed stating that the user is already a delegate, and the registration form is no longer shown.

### How to test it?
- Log in as a delegate
- Go to http://localhost:8080/#/main/voting/register-delegate

### Review checklist
- [x] The PR solves #946 
- [x] All new code is covered with unit tests
- ~~All new features are covered with e2e tests~~. No new features added
- [x] All new code follows best practices
