### PR TITLE
Long Passphrase bug fix - Closes #986 

### DIFF
--- a/src/utils/passphrase.js
+++ b/src/utils/passphrase.js
@@ -89,5 +89,13 @@ export const generatePassphrase = ({ seed }) => (new mnemonic(new Buffer(seed.jo
    */
 export const isValidPassphrase = (passphrase) => {
   const normalizedValue = passphrase.replace(/ +/g, ' ').trim().toLowerCase();
-  return normalizedValue.split(' ').length >= 12 && mnemonic.isValid(normalizedValue);
+  let isValid;
+  try {
+    isValid = normalizedValue.split(' ').length >= 12 && mnemonic.isValid(normalizedValue);
+  } catch (e) {
+    // If the mnemonic check throws an error, we assume that the
+    // passphrase being entered isn't valid
+    isValid = false;
+  }
+  return isValid;
 };

--- a/src/utils/passphrase.test.js
+++ b/src/utils/passphrase.test.js
@@ -129,5 +129,10 @@ describe('Passphrase', () => {
       const passphrase = 'stock borrow episode laundry kitten salute link globe zero feed marble';
       expect(isValidPassphrase(passphrase)).to.be.equal(false);
     });
+
+    it('recognises an invalid passphrase', () => {
+      const passphrase = 'stock borrow episode laundry kitten salute link globe zero feed marble tow fee';
+      expect(isValidPassphrase(passphrase)).to.be.equal(false);
+    });
   });
 });


### PR DESCRIPTION
### What was the problem?
Entering a 13-word passphrase would throw an error in the console, preventing further checks.

### How did I fix it?
I set up a try/catch statement where the error was being thrown. If an error is caught, the `isValidPassphrase` method returns false. This assumes that if an error is thrown from the mnemonic library, the passphrase is invalid.

The error is thrown from a 3rd party lib, so there isn't much that can be done to resolve the issue there.

QUESTION: on [line 92](https://github.com/LiskHQ/lisk-nano/compare/development...joerodrig:passphrase-bugfix?expand=1#diff-9a8c640481b9abdd0204e6a4949e6b09L92), there's a check in place to ensure that the passphrase is greater than or equal to 12 words, based off of spaces. If that check was to verify whether the passphrase contains EXACTLY 12 spaces, this issue could also be resolved. Is there a case where the passphrase can be valid with more than 12 spaces? I was unable to find anything to confirm that.

### How to test it?
- Open nano
- Enter 12-word passphrase, e.g.awkward service glimpse punch genre calm grow life bullet boil match like
- type one more valid word, e.g. life
- You should see the error "Passphrase is not valid"

### Review checklist
- [x] The PR solves #986 
- [x] All new code is covered with unit tests
- ~~All new features are covered with e2e tests~~ No new features
- [x] All new code follows best practices
