### PR TITLE
 Add eslint no-exclusive-tests rule - Closes #893

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
     "plugin:react/recommended"
   ],
   "plugins": [
-    "import"
+    "import",
+    "mocha"
   ],
   "globals": {
     "describe": true,
@@ -20,6 +21,7 @@
     "node": true
   },
   "rules": {
+    "mocha/no-exclusive-tests": "error",
     "func-names": "off",
     "global-require": "off",
     "new-cap": ["error", {
@@ -48,5 +50,10 @@
     ],
     "linebreak-style": 0,
     "no-param-reassign": "off"
+  },
+  "settings": {
+    "mocha/additionalTestFunctions": [
+      "describeModule"
+    ]
   }
 }

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai'; // eslint-disable-line import/no-extraneous-depen
 import sinon, { spy } from 'sinon'; // eslint-disable-line import/no-extraneous-dependencies
 import autoUpdater from './autoUpdater';
 
-describe.only('autoUpdater', () => {
+describe('autoUpdater', () => {
   const version = '1.2.3';
   let params;
   let callbacks;

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-loader": "1.9.0",
     "eslint-plugin-html": "3.2.2",
     "eslint-plugin-import": "2.7.0",
+    "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-react": "7.4.0",
     "exports-loader": "0.6.4",
     "extract-text-webpack-plugin": "3.0.0",


### PR DESCRIPTION
### What was the problem?
We could forget `.only` in our tests

### How did I fix it?
Add eslint no-exclusive-tests rule

### How to test it?
Use `.only` and run `npm run eslint`

### Review checklist
- [ ] The PR solves #893 
