### PR TITLE
Fix account switching with custom node - Closes #995

### DIFF
--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -18,7 +18,10 @@ const savedAccountsMiddleware = store => next => (action) => {
       store.dispatch(accountLoggedOut());
       store.dispatch(activePeerSet({
         publicKey: action.data.publicKey,
-        network: getNetwork(action.data.network),
+        network: {
+          ...getNetwork(action.data.network),
+          address: action.data.address,
+        },
       }));
       break;
     default:

--- a/src/store/middlewares/savedAccounts.test.js
+++ b/src/store/middlewares/savedAccounts.test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import { spy, mock } from 'sinon';
+import { spy, mock, match } from 'sinon';
 
 import { accountLoggedOut } from '../../actions/account';
+import * as peersActions from '../../actions/peers';
 import { successToastDisplayed } from '../../actions/toaster';
 import actionTypes from '../../constants/actions';
 import middleware from './savedAccounts';
@@ -9,6 +10,8 @@ import middleware from './savedAccounts';
 describe('SavedAccounts middleware', () => {
   let store;
   let next;
+  const address = 'https://testnet.lisk.io';
+  const publicKey = 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88';
 
   beforeEach(() => {
     store = mock();
@@ -50,11 +53,35 @@ describe('SavedAccounts middleware', () => {
     const action = {
       type: actionTypes.accountSwitched,
       data: {
-        publicKey: '',
+        publicKey,
         network: 0,
       },
     };
     middleware(store)(next)(action);
     expect(store.dispatch).to.have.been.calledWith(accountLoggedOut());
+  });
+
+  it(`should call activePeerSet action on ${actionTypes.accountSwitched} action`, () => {
+    const code = 2;
+    const peersActionsMock = mock(peersActions);
+    peersActionsMock.expects('activePeerSet').withExactArgs(match({
+      network: {
+        address,
+        code,
+      },
+      publicKey,
+    }));
+
+    const action = {
+      type: actionTypes.accountSwitched,
+      data: {
+        publicKey,
+        network: code,
+        address,
+      },
+    };
+    middleware(store)(next)(action);
+
+    peersActionsMock.verify();
   });
 });

--- a/test/e2e/savedAccounts.feature
+++ b/test/e2e/savedAccounts.feature
@@ -52,7 +52,6 @@ Feature: Saved Accounts
     And I click "forget button"
     Then I should see "saved accounts table" table with 1 lines
 
-  @pending
   Scenario: should allow to switch account
     Given I'm logged in as "genesis"
     When I click "saved accounts" in main menu


### PR DESCRIPTION
### What was the problem?
Account switching with custom node didn't work because the savedAccounts middleware didn't provide `address` to `activePeerSet` action.

### How did I fix it?
By providing the `address` to `activePeerSet` action

### How to test it?
Follow steps in #995 

### Review checklist
- [x] The PR solves #995
- [x] All new code is covered with unit tests
- [x] All new features are covered with e2e tests
- [x] All new code follows best practices
