### PR TITLE
Fix autocomplete when changing a vote - Closes #990

### DIFF
--- a/src/store/reducers/voting.js
+++ b/src/store/reducers/voting.js
@@ -66,20 +66,26 @@ const voting = (state = {
         refresh: true,
       });
 
-    case actionTypes.voteToggled:
+    case actionTypes.voteToggled: {
+      const { username, publicKey } = action.data;
+
+      const newVotes = Object.assign({}, state.votes);
+      const currentVote = state.votes[username];
+      if (currentVote && currentVote.unconfirmed && !currentVote.confirmed) {
+        delete newVotes[action.data.username];
+      } else {
+        newVotes[username] = {
+          confirmed: currentVote ? currentVote.confirmed : false,
+          unconfirmed: currentVote ? !currentVote.unconfirmed : true,
+          publicKey,
+        };
+      }
+
       return Object.assign({}, state, {
         refresh: false,
-        votes: Object.assign({}, state.votes, {
-          [action.data.username]: {
-            confirmed: state.votes[action.data.username] ?
-              state.votes[action.data.username].confirmed : false,
-            unconfirmed: state.votes[action.data.username] ?
-              !state.votes[action.data.username].unconfirmed : true,
-            publicKey: action.data.publicKey,
-          },
-        }),
+        votes: newVotes,
       });
-
+    }
 
     case actionTypes.accountLoggedOut:
       return Object.assign({}, state, {

--- a/src/store/reducers/voting.test.js
+++ b/src/store/reducers/voting.test.js
@@ -150,6 +150,25 @@ describe('Reducer: voting(state, action)', () => {
     expect(changedState).to.be.deep.equal(expectedState);
   });
 
+  it('should remove from votes dictionary if unconfirmed state, with action: voteToggled', () => {
+    const action = {
+      type: actionTypes.voteToggled,
+      data: delegates1[0],
+    };
+    const state = {
+      votes: {
+        [delegates1[0].username]: { confirmed: false, unconfirmed: true },
+      },
+    };
+    const expectedState = {
+      votes: {},
+      refresh: false,
+    };
+    const changedState = voting(state, action);
+
+    expect(changedState).to.be.deep.equal(expectedState);
+  });
+
   it('should mark the toggles votes as pending, with action: pendingVotesAdded ', () => {
     const action = {
       type: actionTypes.pendingVotesAdded,


### PR DESCRIPTION
### What was the problem?

Described here #990 

### How did I fix it?

Previously when we had toggled and untoggled specified vote, reducer state was with false state (vote.confirmed and vote.unconfirmed were false). I've changed it in a way that when user untoggled vote and state of this vote is unconfirmed I'm removing this vote from state, so final state is the same as initial state (before toggling vote).

### How to test it?

Described here #990 

### Review checklist
- [x] The PR solves #990 
- [x] All new code is covered with unit tests
- [x] All new code follows best practices