### PR TITLE
Fix transaction update problem

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -27,7 +27,7 @@ const updateAccountData = (store, action) => {
 
   getAccount(peers.data, account.address).then((result) => {
     if (result.balance !== account.balance) {
-      if (!action.data.windowIsFocused || transactions.count === 0) {
+      if (!action.data.windowIsFocused || !hasRecentTransactions(transactions)) {
         updateTransactions(store, peers, account);
       }
       if (account.isDelegate) {

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -23,11 +23,11 @@ const hasRecentTransactions = txs => (
 );
 
 const updateAccountData = (store, action) => {
-  const { peers, account } = store.getState();
+  const { peers, account, transactions } = store.getState();
 
   getAccount(peers.data, account.address).then((result) => {
     if (result.balance !== account.balance) {
-      if (!action.data.windowIsFocused) {
+      if (!action.data.windowIsFocused || transactions.count === 0) {
         updateTransactions(store, peers, account);
       }
       if (account.isDelegate) {

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -119,6 +119,17 @@ describe('Account middleware', () => {
     expect(stubTransactions).to.have.been.calledWith();
   });
 
+  it(`should call transactions API methods on ${actionTypes.newBlockCreated} action if account.balance changes the user has no transactions yet`, () => {
+    stubGetAccount.resolves({ balance: 10e8 });
+
+    state.transactions.count = 0;
+    middleware(store)(next)(newBlockCreated);
+
+    expect(stubGetAccount).to.have.been.calledWith();
+    // eslint-disable-next-line no-unused-expressions
+    expect(stubTransactions).to.have.been.calledTwice;
+  });
+
   it(`should call transactions API methods on ${actionTypes.newBlockCreated} action if the window is in focus and there are recent transactions`, () => {
     stubGetAccount.resolves({ balance: 0 });
 

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -127,7 +127,7 @@ describe('Account middleware', () => {
 
     expect(stubGetAccount).to.have.been.calledWith();
     // eslint-disable-next-line no-unused-expressions
-    expect(stubTransactions).to.have.been.calledTwice;
+    expect(stubTransactions).to.have.been.calledOnce;
   });
 
   it(`should call transactions API methods on ${actionTypes.newBlockCreated} action if the window is in focus and there are recent transactions`, () => {


### PR DESCRIPTION
### What was the problem?
The transactions didn't update for a new user without transactions

### How did I fix it?
Added an extra condition to check the transaction count

### How to test it?
- Open nano
- Select testnet or custom node network
- Create a new account
- In another machine, send some LSK to that account
- Wait for the transaction to arrive

### Review checklist
- [x] The PR solves https://github.com/LiskHQ/lisk-nano/issues/1002
- [x] All new code is covered with unit tests
- [x] All new code follows best practices
