### PR TITLE
Change German translation for vote button - Closes #1005

### DIFF
--- a/i18n/locales/de/common.json
+++ b/i18n/locales/de/common.json
@@ -182,7 +182,7 @@
   "Verify message": "Nachricht verifizieren",
   "Version": "Version",
   "View": "Ansicht",
-  "Vote": "Abstimmung",
+  "Vote": "Abstimmen",
   "Vote for delegates": "Für Delegierte stimmen",
   "Voting": "Abstimmung",
   "What's New...": "Neues...",

--- a/i18n/locales/de/common.json
+++ b/i18n/locales/de/common.json
@@ -182,7 +182,7 @@
   "Verify message": "Nachricht verifizieren",
   "Version": "Version",
   "View": "Ansicht",
-  "Vote": "Stimme",
+  "Vote": "Abstimmung",
   "Vote for delegates": "Für Delegierte stimmen",
   "Voting": "Abstimmung",
   "What's New...": "Neues...",

--- a/i18n/locales/de/common.json
+++ b/i18n/locales/de/common.json
@@ -1,5 +1,7 @@
 {
   " Make sure that you are using the latest version of Lisk Nano.": "Stelle sicher, dass du die neuste Version von Lisk Nano benutzt.",
+  "Vote_noun": "Abstimmung",
+  "Vote_verb": "Abstimmen",
   "About": "Über",
   "Account saved": "Konto gespeichert",
   "Account was successfully forgotten.": "Das Konto wurde erfolgreich vergessen.",
@@ -184,7 +186,7 @@
   "View": "Ansicht",
   "Vote": "Abstimmen",
   "Vote for delegates": "Für Delegierte stimmen",
-  "Voting": "Abstimmung",
+  "Voting": "Abstimmen",
   "What's New...": "Neues...",
   "When you have the signature, you only need the publicKey of the signer in order to verify that the message came from the right private/publicKey pair. Be aware, everybody knowing the signature and the publicKey can verify the message. If ever there is a dispute, everybody can take the publicKey and signature to a judge and prove that the message is coming from the specific private/publicKey pair.": "Wenn du eine Signatur hast, brauchst du nur noch den öffentlichen Schlüssel des Unterzeichners, um zu überprüfen, ob die Nachricht von dem korrekten privaten/öffentlichen Schlüssel-Paar kommt. Bedenke dass jeder, der den öffentlichen Schlüssel besitzt, die Nachricht verifizieren kann. Wenn es eine Streitigkeit geben sollte, kann jeder den öffentlichen Schlüssel und die Signatur zu einem Richter bringen und dort beweisen, dass die Nachricht von diesem speziellen privaten/öffentlichen Schlüssel-Paar kommt.",
   "Window": "Fenster",

--- a/i18n/locales/de/common.json
+++ b/i18n/locales/de/common.json
@@ -186,7 +186,7 @@
   "View": "Ansicht",
   "Vote": "Abstimmen",
   "Vote for delegates": "Für Delegierte stimmen",
-  "Voting": "Abstimmen",
+  "Voting": "Abstimmung",
   "What's New...": "Neues...",
   "When you have the signature, you only need the publicKey of the signer in order to verify that the message came from the right private/publicKey pair. Be aware, everybody knowing the signature and the publicKey can verify the message. If ever there is a dispute, everybody can take the publicKey and signature to a judge and prove that the message is coming from the specific private/publicKey pair.": "Wenn du eine Signatur hast, brauchst du nur noch den öffentlichen Schlüssel des Unterzeichners, um zu überprüfen, ob die Nachricht von dem korrekten privaten/öffentlichen Schlüssel-Paar kommt. Bedenke dass jeder, der den öffentlichen Schlüssel besitzt, die Nachricht verifizieren kann. Wenn es eine Streitigkeit geben sollte, kann jeder den öffentlichen Schlüssel und die Signatur zu einem Richter bringen und dort beweisen, dass die Nachricht von diesem speziellen privaten/öffentlichen Schlüssel-Paar kommt.",
   "Window": "Fenster",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -1,7 +1,5 @@
 {
   " Make sure that you are using the latest version of Lisk Nano.": " Make sure that you are using the latest version of Lisk Nano.",
-  "Vote_noun": "Vote",
-  "Vote_verb": "Vote",
   "About": "About",
   "Account saved": "Account saved",
   "Account was successfully forgotten.": "Account was successfully forgotten.",
@@ -184,8 +182,9 @@
   "Verify message": "Verify message",
   "Version": "Version",
   "View": "View",
-  "Vote": "Vote",
   "Vote for delegates": "Vote for delegates",
+  "Vote_noun": "Vote",
+  "Vote_verb": "Vote",
   "Voting": "Voting",
   "What's New...": "What's New...",
   "When you have the signature, you only need the publicKey of the signer in order to verify that the message came from the right private/publicKey pair. Be aware, everybody knowing the signature and the publicKey can verify the message. If ever there is a dispute, everybody can take the publicKey and signature to a judge and prove that the message is coming from the specific private/publicKey pair.": "When you have the signature, you only need the publicKey of the signer in order to verify that the message came from the right private/publicKey pair. Be aware, everybody knowing the signature and the publicKey can verify the message. If ever there is a dispute, everybody can take the publicKey and signature to a judge and prove that the message is coming from the specific private/publicKey pair.",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -1,5 +1,7 @@
 {
   " Make sure that you are using the latest version of Lisk Nano.": " Make sure that you are using the latest version of Lisk Nano.",
+  "Vote_noun": "Vote",
+  "Vote_verb": "Vote",
   "About": "About",
   "Account saved": "Account saved",
   "Account was successfully forgotten.": "Account was successfully forgotten.",

--- a/src/components/transactions/transactionType.js
+++ b/src/components/transactions/transactionType.js
@@ -15,7 +15,7 @@ const TransactionType = (props) => {
       type = t('Delegate Registration');
       break;
     case 3:
-      type = t('Vote');
+      type = t('Vote', { context: 'noun' });
       break;
     case 4:
       type = t('Multisignature Creation');

--- a/src/components/voting/voting.js
+++ b/src/components/voting/voting.js
@@ -104,7 +104,7 @@ class Voting extends React.Component {
         <div className='verticalScroll'>
           <Table selectable={false} >
             <TableHead displaySelect={false}>
-              <TableCell>{this.props.t('Vote')}</TableCell>
+              <TableCell>{this.props.t('Vote', { context: 'verb' })}</TableCell>
               <TableCell>{this.props.t('Rank')}</TableCell>
               <TableCell>{this.props.t('Name')}</TableCell>
               <TableCell>{this.props.t('Lisk Address')}</TableCell>

--- a/src/components/voting/votingHeader.js
+++ b/src/components/voting/votingHeader.js
@@ -38,7 +38,7 @@ export class VotingHeaderRaw extends React.Component {
   }
 
   confirmVoteText() {
-    let info = this.props.t('Vote');
+    let info = this.props.t('Vote', { context: 'verb' });
     const { votes } = this.props;
     const votesList = Object.keys(votes);
     const voted = votesList.filter(item =>
@@ -49,7 +49,7 @@ export class VotingHeaderRaw extends React.Component {
       const separator = (voted > 0 && unvoted > 0) ? ' / ' : ''; // eslint-disable-line
       const votedHtml = voted > 0 ? <span className={styles.voted}>+{voted}</span> : '';
       const unvotedHtml = unvoted > 0 ? <span className={styles.unvoted}>-{unvoted}</span> : '';
-      info = <span className='vote-button-info'>{this.props.t('Vote')} ({votedHtml}{separator}{unvotedHtml})</span>;
+      info = <span className='vote-button-info'>{this.props.t('Vote', { context: 'verb' })} ({votedHtml}{separator}{unvotedHtml})</span>;
     }
     return info;
   }


### PR DESCRIPTION
Manual push by LingoHub User: gina contrino.
Project: lisk-nano

Made with :heart: by https://lingohub.com

### What was the problem?
"Stimme" didn't seem to be obvious enough for "Vote"

### How did I fix it?
Changed it to "Abstimmung"

### How to test it?
It should look like this:

the tag should be "Abstimmung"
<img width="1384" alt="screen shot 2017-11-22 at 15 48 02" src="https://user-images.githubusercontent.com/9592216/33133346-bfcb3d78-cf9c-11e7-9661-3ca7bc71d1fe.png">

And in the voting section is should be "Abstimmen"
<img width="1401" alt="screen shot 2017-11-22 at 15 48 12" src="https://user-images.githubusercontent.com/9592216/33133348-bfe59d80-cf9c-11e7-8acb-af0b3026f673.png">

### Review checklist
- [x] The PR solves https://github.com/LiskHQ/lisk-nano/issues/1005

