### PR TITLE
Fix sign message to allow to make changes and sign again

### DIFF
--- a/src/components/signMessage/signMessage.js
+++ b/src/components/signMessage/signMessage.js
@@ -31,6 +31,7 @@ class SignMessageComponent extends React.Component {
         value,
         error,
       },
+      result: undefined,
     });
   }
 
@@ -39,7 +40,7 @@ class SignMessageComponent extends React.Component {
       this.state.passphrase.value);
     const result = Lisk.crypto.printSignedMessage(
       message, signedMessage, this.props.account.publicKey);
-    this.setState({ result, resultIsShown: false });
+    this.setState({ result });
   }
 
   showResult(event) {
@@ -51,7 +52,6 @@ class SignMessageComponent extends React.Component {
     if (copied) {
       this.props.successToast({ label: this.props.t('Result copied to clipboard') });
     }
-    this.setState({ resultIsShown: true });
   }
 
   render() {
@@ -73,7 +73,7 @@ class SignMessageComponent extends React.Component {
               secondPassphrase={this.state.secondPassphrase}
               onChange={this.handleChange.bind(this)} />
           </section>
-          {this.state.resultIsShown ?
+          {this.state.result ?
             <SignVerifyResult result={this.state.result} title={this.props.t('Result')} /> :
             <ActionBar
               secondaryButton={{
@@ -84,7 +84,7 @@ class SignMessageComponent extends React.Component {
                 className: 'sign-button',
                 type: 'submit',
                 disabled: (!this.state.message.value ||
-                  this.state.resultIsShown ||
+                  this.state.result ||
                   !authStateIsValid(this.state)),
               }} />
           }

--- a/src/components/signMessage/signMessage.test.js
+++ b/src/components/signMessage/signMessage.test.js
@@ -16,21 +16,24 @@ describe('SignMessage', () => {
   let store;
   let options;
   const publicKey = 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f';
-  const signature = '079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7' +
+  const signature1 = '079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7' +
     'd7f343854b0c619b647b81ba3f29b23edb4eaf382a47c534746bad4529560b48656c6c6f20776f726c64';
-  const message = 'Hello world';
+  const signature2 = '40f339db0d00f7909ab3818a1181e1fcb4139c9cb092c56aa88108b821eb6769bb' +
+    '970a99edf2ec60729612fb04a4470cc190786fcb5142b72a6b2a0100e7f90148656c6c6f203220776f726c6473';
+  const message1 = 'Hello world';
+  const message2 = 'Hello 2 worlds';
   const account = {
     passphrase: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
     publicKey,
   };
-  const result = `-----BEGIN LISK SIGNED MESSAGE-----
+  const getResult = (message, signature) => (`-----BEGIN LISK SIGNED MESSAGE-----
 -----MESSAGE-----
 ${message}
 -----PUBLIC KEY-----
 ${publicKey}
 -----SIGNATURE-----
 ${signature}
------END LISK SIGNED MESSAGE-----`;
+-----END LISK SIGNED MESSAGE-----`);
 
   beforeEach(() => {
     successToastSpy = sinon.spy();
@@ -57,9 +60,24 @@ ${signature}
 
   it('allows to sign a message, copies sign message result to clipboard and shows success toast', () => {
     copyMock.returns(true);
-    wrapper.find('.message textarea').simulate('change', { target: { value: message } });
+    wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(result);
+    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
+    expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
+  });
+
+  it('allows to sign multiple messages, shows the signed message and success toast each time', () => {
+    copyMock.returns(true);
+    wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
+    wrapper.find('#signMessageForm').simulate('submit');
+    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
+    expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
+
+    copyMock.reset();
+    copyMock.returns(true);
+    wrapper.find('.message textarea').simulate('change', { target: { value: message2 } });
+    wrapper.find('#signMessageForm').simulate('submit');
+    expect(wrapper.find('.result Input').text()).to.equal(getResult(message2, signature2));
     expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
   });
 
@@ -86,16 +104,16 @@ ${signature}
       },
     });
 
-    wrapper.find('.message textarea').simulate('change', { target: { value: message } });
+    wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
     wrapper.find('.passphrase input').simulate('change', { target: { value: account.passphrase } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(result);
+    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
   });
 
   it('does not show success toast if copy-to-clipboard failed', () => {
     copyMock.returns(false);
-    wrapper.find('.message textarea').simulate('change', { target: { value: message } });
-    wrapper.find('.primary-button').simulate('click');
+    wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
+    wrapper.find('#signMessageForm').simulate('submit');
     expect(successToastSpy).to.have.not.been.calledWith();
   });
 });


### PR DESCRIPTION
### What was the problem?
Once the "Sign" button was clicked, the user could not change the message and sign again.
### How did I fix it?
Show the buttons again if the message is changed.
### How to test it?
- Open sign message dialog
- Enter a message and sign
- Change the message and sign again
### Review checklist
- [ ] All new code is covered with unit tests
- [ ] All new code follows best practices
