### PR TITLE
Fix error: cannot read property getPrimaryDisplay of null - Closes #1025

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -11,7 +11,11 @@ const checkForUpdates = updateChecker({ autoUpdater, dialog: electron.dialog, wi
 
 const { app, ipcMain } = electron;
 
+let appIsReady = false;
+
+
 app.on('ready', () => {
+  appIsReady = true;
   win.create({ electron, path, electronLocalshortcut, storage, checkForUpdates });
 });
 
@@ -28,7 +32,9 @@ if (process.platform === 'darwin') {
 }
 
 app.on('activate', () => {
-  if (win.browser === null) {
+  // sometimes, the event is triggered before app.on('ready', ...)
+  // then creating new windows will fail
+  if (win.browser === null && appIsReady) {
     win.create({ electron, path, electronLocalshortcut, storage, checkForUpdates });
   }
 });


### PR DESCRIPTION
### What was the problem?
> It appears that OS X is triggering the activate event before the app is ready for some reason, which means that electron.screen hasn't loaded yet.

which causes `cannot read property getPrimaryDisplay of null` error

### How did I fix it?
As suggested in https://github.com/LiskHQ/lisk-nano/issues/1025#issuecomment-356042696

### How to test it?
It might be hard due to random nature of the bug, but here is one hint:

> According to the Electron docs, this event "usually happens when the user clicks on the application’s dock icon", but I guess it can happen at other times as well.

### Review checklist
- The PR solves #1025
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
