### PR TITLE
Prevent multiple clicks on "send" button - Closes #1036

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "i18next": "=10.0.3",
     "i18next-localstorage-cache": "=1.1.1",
     "i18next-xhr-backend": "=1.4.2",
-    "lisk-js": "0.5.0",
+    "lisk-js": "0.5.1",
     "moment": "2.20.1",
     "numeral": "=2.0.6",
     "postcss": "6.0.12",

--- a/src/components/registerDelegate/registerDelegate.js
+++ b/src/components/registerDelegate/registerDelegate.js
@@ -38,6 +38,7 @@ class RegisterDelegate extends React.Component {
       passphrase: this.state.passphrase.value,
       secondPassphrase: this.state.secondPassphrase.value,
     });
+    this.setState({ executed: true });
   }
 
   render() {
@@ -79,6 +80,7 @@ class RegisterDelegate extends React.Component {
               className: 'register-button',
               disabled: (!this.state.name.value ||
                 this.props.account.isDelegate ||
+                this.state.executed ||
                 !authStateIsValid(this.state)),
             }} />
         </form>

--- a/src/components/registerDelegate/registerDelegate.test.js
+++ b/src/components/registerDelegate/registerDelegate.test.js
@@ -92,8 +92,9 @@ describe('RegisterDelegate', () => {
 
     it('allows register as delegate for a non delegate account', () => {
       wrapper.find('.username input').simulate('change', { target: { value: 'sample_username' } });
+      expect(wrapper.find('.primary-button button')).to.have.prop('disabled', false);
       wrapper.find('button.next-button').simulate('submit');
-      expect(wrapper.find('.primary-button button').props().disabled).to.not.equal(true);
+      expect(wrapper.find('.primary-button button')).to.have.prop('disabled', true);
       expect(props.delegateRegistered).to.have.been.calledWith();
     });
 

--- a/src/components/send/send.js
+++ b/src/components/send/send.js
@@ -72,6 +72,7 @@ class Send extends React.Component {
       passphrase: this.state.passphrase.value,
       secondPassphrase: this.state.secondPassphrase.value,
     });
+    this.setState({ executed: true });
   }
 
   getMaxAmount() {
@@ -115,6 +116,7 @@ class Send extends React.Component {
               label: this.props.t('Send'),
               type: 'submit',
               disabled: (
+                this.state.executed ||
                 !!this.state.recipient.error ||
                 !this.state.recipient.value ||
                 !!this.state.amount.error ||

--- a/src/components/send/send.test.js
+++ b/src/components/send/send.test.js
@@ -92,7 +92,9 @@ describe('Send', () => {
   it('allows to send a transaction', () => {
     wrapper.find('.amount input').simulate('change', { target: { value: '120.25' } });
     wrapper.find('.recipient input').simulate('change', { target: { value: '11004588490103196952L' } });
+    expect(wrapper.find('.primary-button button')).to.have.prop('disabled', false);
     wrapper.find('.primary-button button').simulate('submit');
+    expect(wrapper.find('.primary-button button')).to.have.prop('disabled', true);
     expect(props.sent).to.have.been.calledWith({
       account: props.account,
       activePeer: {},

--- a/src/components/voteDialog/voteDialog.js
+++ b/src/components/voteDialog/voteDialog.js
@@ -31,6 +31,7 @@ export default class VoteDialog extends React.Component {
       secondSecret: this.state.secondPassphrase.value,
       passphrase: this.state.passphrase.value,
     });
+    this.setState({ executed: true });
   }
 
   handleChange(name, value, error) {
@@ -79,6 +80,7 @@ export default class VoteDialog extends React.Component {
               fee: Fees.vote,
               type: 'button',
               disabled: (
+                this.state.executed ||
                 getTotalVotesCount(votes) > maxCountOfVotes ||
                 countOfVotesInOneTurn === 0 ||
                 countOfVotesInOneTurn > maxCountOfVotesInOneTurn ||


### PR DESCRIPTION
### What was the problem?
Send button could be clicked twice
### How did I fix it?

I've set `this.state.ecexuted` to disable the send button.

### How to test it?
To reproduce without the fix, setup dev tools network to have big latency

### Review checklist

- The PR solves #1036
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
