### PR TITLE
Split passphrase by selected index, not by selected word

### DIFF
--- a/src/components/passphrase/passphraseVerifier.js
+++ b/src/components/passphrase/passphraseVerifier.js
@@ -21,8 +21,11 @@ class PassphraseConfirmator extends React.Component {
     const words = this.props.passphrase.trim().split(/\s+/).filter(item => item.length > 0);
     const index = Math.floor(rand * (words.length - 1));
 
+    const passphraseBeforeHiddenWord = words.slice(0, index).join(' ');
+    const passphraseAfterHiddenWord = words.slice(index + 1).join(' ');
+
     this.setState({
-      passphraseParts: this.props.passphrase.split(words[index]),
+      passphraseParts: [passphraseBeforeHiddenWord, passphraseAfterHiddenWord],
       missing: words[index],
       answer: '',
     });

--- a/src/components/passphrase/passphraseVerifier.test.js
+++ b/src/components/passphrase/passphraseVerifier.test.js
@@ -47,9 +47,9 @@ describe('PassphraseVerifier', () => {
 
   it('should break passphrase, hide a word and show it', () => {
     const expectedValues = [
-      'survey stereo pool fortune oblige ',
+      'survey stereo pool fortune oblige',
       '-----',
-      ' gravity goddess mistake sentence anchor pool',
+      'gravity goddess mistake sentence anchor pool',
     ];
     const spanTags = wrapper.find('.passphrase-holder span');
 


### PR DESCRIPTION
### What was the problem?

Splitting by word leads to incorrect results as soon as a word occurs
more than one time in a passphrase.

### How did I fix it?

Split by index

### How to test it?

`npm test` and creating an account in the app

### Review checklist
- [ ] The PR solves #1050
- [ ] All new code is covered with unit tests
- [ ] All new features are covered with e2e tests
- [ ] All new code follows best practices
