### PR TITLE
Keep selected network option when creating new ID - Closes #1031

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -100,6 +100,10 @@ class Login extends React.Component {
       [name]: value,
       ...validator(value, error),
     });
+
+    if (name === 'network' || name === 'address') {
+      localStorage.setItem(name, value);
+    }
   }
 
   devPreFill() {


### PR DESCRIPTION
### What was the problem?
The selected network option reverted to mainnet when trying to create a new ID

### How did I fix it?
By saving the selected network option in localStorage

### How to test it?
Select a network option & create a new account -> afterwards you should be logged in with the option you selected

### Review checklist
- [ ] The PR solves #1031
- [ ] All new code is covered with unit tests
- [ ] All new features are covered with e2e tests
- [ ] All new code follows best practices
