### PR TITLE
Disallow lowercase l in address - Closes #1070

### DIFF
--- a/src/components/send/send.js
+++ b/src/components/send/send.js
@@ -26,7 +26,7 @@ class Send extends React.Component {
       ...authStatePrefill(),
     };
     this.inputValidationRegexps = {
-      recipient: /^\d{1,21}[L|l]$/,
+      recipient: /^\d{1,21}L$/,
       amount: /^\d+(\.\d{1,8})?$/,
     };
   }

--- a/src/utils/api/account.js
+++ b/src/utils/api/account.js
@@ -1,7 +1,7 @@
 import Lisk from 'lisk-js';
 
 export const getAccount = (activePeer, address) =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     activePeer.accounts.get({ address }).then((res) => {
       if (res.data.length > 0) {
         resolve({
@@ -16,21 +16,21 @@ export const getAccount = (activePeer, address) =>
           balance: 0,
         });
       }
-    });
+    }).catch(reject);
   });
 
 export const setSecondPassphrase = (activePeer, secondPassphrase, publicKey, passphrase) =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const transaction = Lisk.transaction
       .registerSecondPassphrase({ passphrase, secondPassphrase });
     activePeer.transactions.broadcast(transaction).then(() => {
       resolve(transaction);
-    });
+    }).catch(reject);
   });
 
 export const send = (activePeer, recipientId, amount,
   passphrase, secondPassphrase = null, data = null) =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const transaction = Lisk.transaction
       .transfer({
         recipientId,
@@ -41,7 +41,7 @@ export const send = (activePeer, recipientId, amount,
       });
     activePeer.transactions.broadcast(transaction).then(() => {
       resolve(transaction);
-    });
+    }).catch(reject);
   });
 
 export const transactions = (activePeer, address, limit = 20, offset = 0, sort = 'timestamp:desc') =>

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -48,7 +48,7 @@ export const unvoteAutocomplete = (username, votedDict) =>
   );
 
 export const registerDelegate = (activePeer, username, passphrase, secondPassphrase = null) =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const transaction = Lisk.transaction
       .registerDelegate({
         username,
@@ -56,5 +56,5 @@ export const registerDelegate = (activePeer, username, passphrase, secondPassphr
         secondPassphrase });
     activePeer.transactions.broadcast(transaction).then(() => {
       resolve(transaction);
-    });
+    }).catch(reject);
   });


### PR DESCRIPTION
### What was the problem?
Two problems:
- api call failure was not handled
- lowercase l in address was allowed

### How did I fix it?
- handled api call failure
- disabled lowercase l in address

### How to test it?
Try to send a transaction to 234235235l


### Review checklist
- The PR solves #1070
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
