### PR TITLE
Re-enable unit tests after Core 1.0.0 migration - #1072

### DIFF
--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -38,11 +38,11 @@ export const activePeerSet = data =>
       config.port = port || (config.ssl ? 443 : 80);
       config.nodes = [`${protocol}//${hostname}:${port}`];
     } else if (config.testnet) {
-      config.nodes = Lisk.constants.TESTNET_NODES;
-      config.nethash = Lisk.constants.TESTNET_NETHASH;
+      config.nodes = Lisk.APIClient.constants.TESTNET_NODES;
+      config.nethash = Lisk.APIClient.constants.TESTNET_NETHASH;
     } else {
-      config.nodes = Lisk.constants.MAINNET_NODES;
-      config.nethash = Lisk.constants.MAINNET_NETHASH;
+      config.nodes = Lisk.APIClient.constants.MAINNET_NODES;
+      config.nethash = Lisk.APIClient.constants.MAINNET_NETHASH;
     }
 
     if (config.custom) {

--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -1,9 +1,7 @@
 import i18next from 'i18next';
 import Lisk from 'lisk-elements';
 import actionTypes from '../constants/actions';
-// import { getNethash } from './../utils/api/nethash';
 import { errorToastDisplayed } from './toaster';
-import netHashes from '../constants/netHashes';
 import { loadingStarted, loadingFinished } from '../utils/loading';
 
 const peerSet = (data, config) => ({
@@ -39,19 +37,20 @@ export const activePeerSet = data =>
       config.ssl = protocol === 'https:';
       config.port = port || (config.ssl ? 443 : 80);
       config.nodes = [`${protocol}//${hostname}:${port}`];
+    } else if (config.testnet) {
+      config.nodes = Lisk.constants.TESTNET_NODES;
+      config.nethash = Lisk.constants.TESTNET_NETHASH;
+    } else {
+      config.nodes = Lisk.constants.MAINNET_NODES;
+      config.nethash = Lisk.constants.MAINNET_NETHASH;
     }
-    if (config.testnet === undefined && config.port !== undefined) {
-      config.testnet = config.port === '7000';
-    }
+
     if (config.custom) {
-      const getNethash = new Lisk.APIClient(config.nodes, { nethash: config.nethash });
+      const liskAPIClient = new Lisk.APIClient(config.nodes, { nethash: config.nethash });
       loadingStarted('getConstants');
-      getNethash.node.getConstants().then((response) => {
+      liskAPIClient.node.getConstants().then((response) => {
         loadingFinished('getConstants');
-        config.testnet = response.data.nethash === netHashes.testnet;
-        if (!config.testnet && response.data.nethash !== netHashes.mainnet) {
-          config.nethash = response.data.nethash;
-        }
+        config.nethash = response.data.nethash;
         dispatch(peerSet(data, config));
       }).catch(() => {
         loadingFinished('getConstants');

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -40,6 +40,7 @@ describe('actions: peers', () => {
           };
         }
       };
+      Lisk.APIClient.constants = APIClientBackup.constants;
     });
 
     afterEach(() => {
@@ -49,7 +50,7 @@ describe('actions: peers', () => {
     it('dispatch activePeerSet action also when address http missing', () => {
       const network = {
         address: 'localhost:8000',
-        nethash: Lisk.constants.MAINNET_NETHASH,
+        nethash: Lisk.APIClient.constants.MAINNET_NETHASH,
       };
 
       activePeerSet({ passphrase, network })(dispatch);
@@ -60,13 +61,13 @@ describe('actions: peers', () => {
     it('dispatch activePeerSet action with mainnet nodes if network.address is undefined', () => {
       activePeerSet({ passphrase, network: {} })(dispatch);
 
-      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.constants.MAINNET_NODES));
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.APIClient.constants.MAINNET_NODES));
     });
 
     it('dispatch activePeerSet action with mainnet nodes if network is undefined', () => {
       activePeerSet({ passphrase })(dispatch);
 
-      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.constants.MAINNET_NODES));
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.APIClient.constants.MAINNET_NODES));
     });
 
     it('dispatch activePeerSet action with testnet nodes if testnet option is set', () => {
@@ -76,7 +77,7 @@ describe('actions: peers', () => {
 
       activePeerSet({ passphrase, network })(dispatch);
 
-      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.constants.TESTNET_NODES));
+      expect(dispatch).to.have.been.calledWith(match.hasNested('data.options.nodes', Lisk.APIClient.constants.TESTNET_NODES));
     });
 
     it('dispatch activePeerSet action with custom node', () => {

--- a/src/constants/netHashes.js
+++ b/src/constants/netHashes.js
@@ -1,6 +1,0 @@
-const netHash = {
-  testnet: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-  mainnet: 'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
-};
-
-export default netHash;

--- a/src/store/middlewares/login.test.js
+++ b/src/store/middlewares/login.test.js
@@ -10,7 +10,6 @@ describe('Login middleware', () => {
   let store;
   let next;
   const passphrase = 'wagon stock borrow episode laundry kitten salute link globe zero feed marble';
-  const nethash = '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d';
   const activePeer = new Lisk.APIClient(['http://localhost:4000'], {});
 
   const activePeerSetAction = {

--- a/src/store/middlewares/login.test.js
+++ b/src/store/middlewares/login.test.js
@@ -1,6 +1,6 @@
 import Lisk from 'lisk-elements';
 import { expect } from 'chai';
-import { spy, stub, mock } from 'sinon';
+import { spy, stub, match } from 'sinon';
 import middleware from './login';
 import actionTypes from '../../constants/actions';
 import * as accountApi from '../../utils/api/account';
@@ -42,16 +42,11 @@ describe('Login middleware', () => {
     expect(next).to.have.been.calledWith(sampleAction);
   });
 
-  it.skip(`should action data to only have activePeer on ${actionTypes.activePeerSet} action`, () => {
+  it(`should action data to only have activePeer on ${actionTypes.activePeerSet} action`, () => {
     middleware(store)(next)(activePeerSetAction);
-    const peerMock = mock(activePeer.node);
-    peerMock.expects('getConstants').withArgs()
-      .returnsPromise().resolves({ nethash });
-    peerMock.restore();
-    peerMock.verify();
     expect(next).to.have.been.calledWith({
       type: actionTypes.activePeerSet,
-      data: activePeer,
+      data: match.hasNested('activePeer', activePeer),
     });
   });
 
@@ -66,7 +61,7 @@ describe('Login middleware', () => {
     delegateApiMock.restore();
   });
 
-  it.skip(`should fetch account and delegate info on ${actionTypes.activePeerSet} action (delegate)`, () => {
+  it(`should fetch account and delegate info on ${actionTypes.activePeerSet} action (delegate)`, () => {
     const accountApiMock = stub(accountApi, 'getAccount').returnsPromise().resolves({ success: true, balance: 0 });
     const delegateApiMock = stub(delegateApi, 'getDelegate').returnsPromise().resolves({
       success: true,


### PR DESCRIPTION
### What was the problem?
Some tests were skipped (see #1072)

### How did I fix it?
I re-enabled them

### How to test it?
Run the tests, read the tests

### Review checklist
- The PR solves #1072
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
