### PR TITLE
Fix displaying delegate name - Closes #1080

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "i18next": "=10.0.3",
     "i18next-localstorage-cache": "=1.1.1",
     "i18next-xhr-backend": "=1.4.2",
-    "lisk-elements": "1.0.0-beta.4",
+    "lisk-elements": "1.0.0",
     "moment": "2.20.1",
     "numeral": "=2.0.6",
     "postcss": "6.0.12",

--- a/src/components/savedAccounts/savedAccounts.test.js
+++ b/src/components/savedAccounts/savedAccounts.test.js
@@ -16,7 +16,7 @@ describe('SavedAccounts', () => {
   const publicKey = 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88';
   const savedAccounts = [
     {
-      publicKey: 'hab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
+      publicKey: 'eab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
       network: 0,
     },
     {

--- a/src/components/signMessage/signMessage.test.js
+++ b/src/components/signMessage/signMessage.test.js
@@ -16,8 +16,8 @@ describe('SignMessage', () => {
   let store;
   let options;
   const publicKey = 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f';
-  const signature1 = '079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7d7f343854b0c619b647b81ba3f29b23edb4eaf382a47c534746bad4529560b';
-  const signature2 = '40f339db0d00f7909ab3818a1181e1fcb4139c9cb092c56aa88108b821eb6769bb970a99edf2ec60729612fb04a4470cc190786fcb5142b72a6b2a0100e7f901';
+  const signature1 = 'c68adc13131696c35ac82b9bb6884ee4de66ff281b013fe4ded66a73243c860b6a74b759bfb8d25db507ea2bec4bb208f8bb514fa18380416e637db947f0ab06';
+  const signature2 = '29f6be7bac1ac7bc46f6285505ba042ee95bd7ffa473fa4296e18ace905d33c543d6609648fd56a8bd3acfbe90f3bdc2926056d6755a43b2da6bec09cf49d90f';
   const message1 = 'Hello world';
   const message2 = 'Hello 2 worlds';
   const account = {
@@ -60,7 +60,7 @@ ${signature}
     copyMock.returns(true);
     wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
+    expect(wrapper.find('.result Input')).to.have.text(getResult(message1, signature1));
     expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
   });
 
@@ -68,14 +68,14 @@ ${signature}
     copyMock.returns(true);
     wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
+    expect(wrapper.find('.result Input')).to.have.text(getResult(message1, signature1));
     expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
 
     copyMock.reset();
     copyMock.returns(true);
     wrapper.find('.message textarea').simulate('change', { target: { value: message2 } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(getResult(message2, signature2));
+    expect(wrapper.find('.result Input')).to.have.text(getResult(message2, signature2));
     expect(successToastSpy).to.have.been.calledWith({ label: 'Result copied to clipboard' });
   });
 
@@ -105,7 +105,7 @@ ${signature}
     wrapper.find('.message textarea').simulate('change', { target: { value: message1 } });
     wrapper.find('.passphrase input').simulate('change', { target: { value: account.passphrase } });
     wrapper.find('#signMessageForm').simulate('submit');
-    expect(wrapper.find('.result Input').text()).to.equal(getResult(message1, signature1));
+    expect(wrapper.find('.result Input')).to.have.text(getResult(message1, signature1));
   });
 
   it('does not show success toast if copy-to-clipboard failed', () => {

--- a/src/components/verifyMessage/index.test.js
+++ b/src/components/verifyMessage/index.test.js
@@ -8,7 +8,7 @@ import VerifyMessage from './index';
 describe('VerifyMessage', () => {
   let wrapper;
   const publicKey = 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f';
-  const signature = '079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7d7f343854b0c619b647b81ba3f29b23edb4eaf382a47c534746bad4529560b';
+  const signature = 'c68adc13131696c35ac82b9bb6884ee4de66ff281b013fe4ded66a73243c860b6a74b759bfb8d25db507ea2bec4bb208f8bb514fa18380416e637db947f0ab06';
   const message = 'Hello world';
 
   beforeEach(() => {

--- a/src/store/middlewares/transactions.js
+++ b/src/store/middlewares/transactions.js
@@ -21,6 +21,7 @@ const transactionAdded = (store, action) => {
   store.dispatch(newAction);
 };
 
+// eslint-disable-next-line no-unused-vars
 const transactionsUpdated = (store) => {
   const { transactions, account, peers } = store.getState();
   if (transactions.pending.length) {
@@ -39,7 +40,14 @@ const transactionsMiddleware = store => next => (action) => {
       transactionAdded(store, action);
       break;
     case actionTypes.transactionsUpdated:
+      // this was disabled, because this caused pending transactions
+      // to disappear from the list before they appeared again as confirmed.
+      // Currently, the problem is that a pending transaction will not be removed
+      // from the list if it fails. Caused by Lisk Core 1.0.0
+      // TODO: figure out how to make this work again
+      /*
       transactionsUpdated(store, action);
+      */
       break;
     default: break;
   }

--- a/src/store/middlewares/transactions.test.js
+++ b/src/store/middlewares/transactions.test.js
@@ -81,7 +81,8 @@ describe('transaction middleware', () => {
     expect(store.dispatch).to.not.have.been.calledWith();
   });
 
-  it('should call unconfirmedTransactions and then dispatch transactionsFailed if state.transactions.pending.length > 0 and action.type is transactionsUpdated', () => {
+  // TODO update after the functionality is fixed. see implementation for more info
+  it.skip('should call unconfirmedTransactions and then dispatch transactionsFailed if state.transactions.pending.length > 0 and action.type is transactionsUpdated', () => {
     const transactions = [
       mockTransaction,
     ];

--- a/src/utils/savedAccounts.test.js
+++ b/src/utils/savedAccounts.test.js
@@ -13,7 +13,7 @@ describe('savedAccounts', () => {
   const publicKey = 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88';
   const accounts = [
     {
-      publicKey: 'hab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
+      publicKey: 'eab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
       network: 0,
     },
     {

--- a/test/e2e/signMessage.feature
+++ b/test/e2e/signMessage.feature
@@ -12,7 +12,7 @@ Feature: Sign message
          -----PUBLIC KEY-----
          c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f
          -----SIGNATURE-----
-         079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7d7f343854b0c619b647b81ba3f29b23edb4eaf382a47c534746bad4529560b
+         c68adc13131696c35ac82b9bb6884ee4de66ff281b013fe4ded66a73243c860b6a74b759bfb8d25db507ea2bec4bb208f8bb514fa18380416e637db947f0ab06
          -----END LISK SIGNED MESSAGE-----
          """
 

--- a/test/e2e/verifyMessage.feature
+++ b/test/e2e/verifyMessage.feature
@@ -4,7 +4,7 @@ Feature: Verify message
     When I click "verify message" in main menu
     And  I fill in "Hello world" to "message" field
     And  I fill in "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f" to "public key" field
-    And  I fill in "079331d868678fd5f272f09d6dc8792fb21335aec42af7f11caadbfbc17d4707e7d7f343854b0c619b647b81ba3f29b23edb4eaf382a47c534746bad4529560b" to "signature" field
+    And  I fill in "c68adc13131696c35ac82b9bb6884ee4de66ff281b013fe4ded66a73243c860b6a74b759bfb8d25db507ea2bec4bb208f8bb514fa18380416e637db947f0ab06" to "signature" field
     Then I should see "Message verified" in "result" field
 
   @integration


### PR DESCRIPTION
### What was the problem?
When registering a delegate, it never got the transaction confirmed, thus never showed delegate name and "Forging" tab

### How did I fix it?

Similarly to Hub, I stopped checking unconfirmed transactions, so that as long as there is a pending transaction, it will keep trying to fetch confirmed transactions, until the pending transaction is in the confirmed list.

### How to test it?
- Login to a non-delegate account
- Register a delegate
- Wait for the transaction to be confirmed
- Check that the delegate name and Forging tab is displayed.

### Review checklist
-  The PR solves #1080
-  All new code is covered with unit tests
-  All new features are covered with e2e tests
-  All new code follows best practices
